### PR TITLE
chore(tasks): pin region to us-east-1 in 7 task instructions

### DIFF
--- a/tasks/compute-and-data/appstream-stack-with-streaming-vpce/instruction.md
+++ b/tasks/compute-and-data/appstream-stack-with-streaming-vpce/instruction.md
@@ -1,4 +1,4 @@
-Create AWS AppStream 2.0 stack with create-stack that has a VPC endpoint for streaming. The AppStream stack needs to have access endpoints configured for streaming through the VPC endpoint.
+Create an AWS AppStream 2.0 stack in us-east-1 with create-stack that has a VPC endpoint for streaming. The AppStream stack needs to have access endpoints configured for streaming through the VPC endpoint.
 
 IMPORTANT: Write your final prose answer to `/logs/agent/agent-output.txt`.
 

--- a/tasks/compute-and-data/create-medialive-channel/instruction.md
+++ b/tasks/compute-and-data/create-medialive-channel/instruction.md
@@ -1,4 +1,4 @@
-Create a MediaLive channel with all the necessary resources.
+Create a MediaLive channel in us-east-1 with all the necessary resources.
 
 IMPORTANT: Write your final prose answer to `/logs/agent/agent-output.txt`.
 

--- a/tasks/compute-and-data/create-s3-bucket-with-config/instruction.md
+++ b/tasks/compute-and-data/create-s3-bucket-with-config/instruction.md
@@ -1,4 +1,4 @@
-Create a new S3 bucket that blocks all public access, has AES-256 encryption, versioning enabled, and please ensure it is tagged with Environment:Testing, Purpose:AIOperations, Owner:AITeam, Project:AITesting.
+Create a new S3 bucket in us-east-1 that blocks all public access, has AES-256 encryption, versioning enabled, and please ensure it is tagged with Environment:Testing, Purpose:AIOperations, Owner:AITeam, Project:AITesting.
 
 IMPORTANT: Write your final prose answer to `/logs/agent/agent-output.txt`.
 

--- a/tasks/compute-and-data/create-s3-tables-with-compaction/instruction.md
+++ b/tasks/compute-and-data/create-s3-tables-with-compaction/instruction.md
@@ -1,4 +1,4 @@
-Create two S3 tables (one with sort compaction and one without) within an S3 table bucket with some sample data to verify why sort compaction performance varies significantly for different user IDs when using Athena queries.
+Create two S3 tables (one with sort compaction and one without) within an S3 table bucket in us-east-1 with some sample data to verify why sort compaction performance varies significantly for different user IDs when using Athena queries.
 
 IMPORTANT: Write your final prose answer to `/logs/agent/agent-output.txt`.
 

--- a/tasks/compute-and-data/create-vpc-valkey-dynamodb/instruction.md
+++ b/tasks/compute-and-data/create-vpc-valkey-dynamodb/instruction.md
@@ -1,4 +1,4 @@
-Create a storage application by setting up a VPC, Valkey cluster, and DynamoDB table.
+Create a storage application in us-east-1 by setting up a VPC, Valkey cluster, and DynamoDB table.
 
 IMPORTANT: Write your final prose answer to `/logs/agent/agent-output.txt`.
 

--- a/tasks/compute-and-data/managed-ad-with-ldaps-and-resets/instruction.md
+++ b/tasks/compute-and-data/managed-ad-with-ldaps-and-resets/instruction.md
@@ -1,4 +1,4 @@
-Create an AWS Managed Microsoft AD active directory and enable LDAPS on it.
+Create an AWS Managed Microsoft AD active directory in us-east-1 and enable LDAPS on it.
 
 IMPORTANT: Write your final prose answer to `/logs/agent/agent-output.txt`.
 

--- a/tasks/streaming-and-iot/iotsitewise-windfarm-rollup-models/instruction.md
+++ b/tasks/streaming-and-iot/iotsitewise-windfarm-rollup-models/instruction.md
@@ -1,3 +1,3 @@
-Create two IoT SiteWise asset models named exactly `WindTurbineModel` and `WindFarmModel`. The child has an `ActivePower` measurement (`DOUBLE`). The parent has a `TotalActivePower` measurement (`DOUBLE`), a `Turbines` hierarchy referencing the child, and a `FleetAverageActivePower` (`DOUBLE`) metric over a 5-minute tumbling window that averages the child's `ActivePower` across the hierarchy.
+Create two IoT SiteWise asset models in us-east-1 named exactly `WindTurbineModel` and `WindFarmModel`. The child has an `ActivePower` measurement (`DOUBLE`). The parent has a `TotalActivePower` measurement (`DOUBLE`), a `Turbines` hierarchy referencing the child, and a `FleetAverageActivePower` (`DOUBLE`) metric over a 5-minute tumbling window that averages the child's `ActivePower` across the hierarchy.
 
 IMPORTANT: Write your final prose answer to `/logs/agent/agent-output.txt`.


### PR DESCRIPTION
Adds "in us-east-1" to the opening sentence of 7 mutation task instructions so the prompt states the target Region explicitly. Each task already pins `us-east-1` in its `task.toml`; this makes the agent-facing instruction consistent with the environment.

Ported verbatim from the internal `AWSBenchDatasets` working tree (branch `add-scenario-cleanup-phase`).

## Tasks
- compute-and-data/appstream-stack-with-streaming-vpce
- compute-and-data/create-medialive-channel
- compute-and-data/create-s3-bucket-with-config
- compute-and-data/create-s3-tables-with-compaction
- compute-and-data/create-vpc-valkey-dynamodb
- compute-and-data/managed-ad-with-ldaps-and-resets
- streaming-and-iot/iotsitewise-windfarm-rollup-models

## Verification
- `npx jest` — 28/28 pass (instruction trailer, task-field, and mutation output-contract checks).
- Pre-commit judge output-contract check passed (24 mutation tasks in sync).