### PR TITLE
ci: harden Slack notification workflows against script injection

### DIFF
--- a/.github/workflows/issue_notification.yml
+++ b/.github/workflows/issue_notification.yml
@@ -8,13 +8,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Send to Slack
+        env:
+          SLACK_ISSUE_WEBHOOK_URL: ${{ secrets.SLACK_ISSUE_WEBHOOK_URL }}
+          ISSUE_URL: ${{ github.event.issue.html_url }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_ACTION: ${{ github.event.action }}
+          ISSUE_USER: ${{ github.event.issue.user.login }}
+          REPO_NAME: ${{ github.event.repository.full_name }}
         run: |
-          curl -X POST "${{ secrets.SLACK_ISSUE_WEBHOOK_URL }}" \
+          payload="$(jq -n \
+            --arg issue_url "$ISSUE_URL" \
+            --arg issue_title "$ISSUE_TITLE" \
+            --arg action "$ISSUE_ACTION" \
+            --arg user "$ISSUE_USER" \
+            --arg repo_name "$REPO_NAME" \
+            '{issue_url: $issue_url, issue_title: $issue_title, action: $action, user: $user, repo_name: $repo_name}')"
+          curl -X POST "$SLACK_ISSUE_WEBHOOK_URL" \
             -H "Content-Type: application/json" \
-            -d '{
-              "issue_url": "${{ github.event.issue.html_url }}",
-              "issue_title": "${{ github.event.issue.title }}",
-              "action": "${{ github.event.action }}",
-              "user": "${{ github.event.issue.user.login }}",
-              "repo_name": "${{ github.event.repository.full_name }}"
-            }'
+            -d "$payload"

--- a/.github/workflows/pr-notification.yml
+++ b/.github/workflows/pr-notification.yml
@@ -8,13 +8,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Send to Slack
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_ACTION: ${{ github.event.action }}
+          PR_USER: ${{ github.event.pull_request.user.login }}
+          REPO_NAME: ${{ github.event.repository.full_name }}
         run: |
-          curl -X POST "${{ secrets.SLACK_WEBHOOK_URL }}" \
+          payload="$(jq -n \
+            --arg pr_url "$PR_URL" \
+            --arg pr_title "$PR_TITLE" \
+            --arg action "$PR_ACTION" \
+            --arg user "$PR_USER" \
+            --arg repo_name "$REPO_NAME" \
+            '{pr_url: $pr_url, pr_title: $pr_title, action: $action, user: $user, repo_name: $repo_name}')"
+          curl -X POST "$SLACK_WEBHOOK_URL" \
             -H "Content-Type: application/json" \
-            -d '{
-              "pr_url": "${{ github.event.pull_request.html_url }}",
-              "pr_title": "${{ github.event.pull_request.title }}",
-              "action": "${{ github.event.action }}",
-              "user": "${{ github.event.pull_request.user.login }}",
-              "repo_name": "${{ github.event.repository.full_name }}"
-            }'
+            -d "$payload"


### PR DESCRIPTION
*Description of changes:*
Pass GitHub event context through env vars and build the JSON payload with jq instead of interpolating untrusted issue/PR titles directly into the curl command.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
