### PR TITLE
Enforce TLS 1.2 minimum in apigateway setup script

### DIFF
--- a/scenarios/api-and-observability/scenario/setup/setup_apigateway_we36rki7x.py
+++ b/scenarios/api-and-observability/scenario/setup/setup_apigateway_we36rki7x.py
@@ -34,9 +34,9 @@ def _ws_connect_and_send(url, payload, timeout=5):
     parsed = urllib.parse.urlparse(url)
     raw = socket.create_connection((parsed.hostname, 443), timeout=timeout)
     try:
-        sock = ssl.create_default_context().wrap_socket(
-            raw, server_hostname=parsed.hostname
-        )
+        context = ssl.create_default_context()
+        context.minimum_version = ssl.TLSVersion.TLSv1_2
+        sock = context.wrap_socket(raw, server_hostname=parsed.hostname)
     except Exception:
         raw.close()
         raise


### PR DESCRIPTION
## Summary
Sets `context.minimum_version = ssl.TLSVersion.TLSv1_2` on the SSL context used for the WebSocket handshake in `scenarios/api-and-observability/scenario/setup/setup_apigateway_we36rki7x.py`, so TLS 1.0/1.1 are no longer permitted.

This clears the CodeQL `py/insecure-protocol` warning ("Insecure SSL/TLS protocol version TLSv1 / TLSv1_1 allowed by call to ssl.create_default_context") using the recommended `minimum_version` approach.

## Change
```python
context = ssl.create_default_context()
context.minimum_version = ssl.TLSVersion.TLSv1_2
sock = context.wrap_socket(raw, server_hostname=parsed.hostname)
```

## Testing
- `make py` green (ruff lint + format check on 626 files, ty).
- Live `aws-bench env setup` re-run for api-and-observability: container rebuilt, all 13 setup scripts ran, `setup_apigateway_we36rki7x.py` completed OK against the live `wss://` API Gateway endpoint — confirming the TLS 1.2 pin is behavior-preserving (the endpoint already negotiates TLS 1.2+).

