### PR TITLE
fix(verifier): ensure check.py uses correct region scoping

### DIFF
--- a/tasks/compute-and-data/appstream-stack-with-streaming-vpce/task.toml
+++ b/tasks/compute-and-data/appstream-stack-with-streaming-vpce/task.toml
@@ -35,6 +35,9 @@ timeout_sec = 4800.0
 [verifier]
 timeout_sec = 360.0
 
+[verifier.env]
+AWS_REGION = "us-east-1"
+
 [solution.env]
 AWS_DEFAULT_REGION = "us-east-1"
 

--- a/tasks/compute-and-data/appstream-stack-with-streaming-vpce/tests/check.py
+++ b/tasks/compute-and-data/appstream-stack-with-streaming-vpce/tests/check.py
@@ -17,7 +17,7 @@ import boto3
 from botocore.exceptions import ClientError
 from rewardkit import criterion
 
-REGION = os.environ.get("AWS_DEFAULT_REGION", "us-east-1")
+REGION = os.environ.get("AWS_REGION", os.environ.get("AWS_DEFAULT_REGION", "us-east-1"))
 
 try:
     AGENT_OUTPUT = json.loads(Path("/logs/agent/agent-output.json").read_text())

--- a/tasks/compute-and-data/create-eks-cluster/task.toml
+++ b/tasks/compute-and-data/create-eks-cluster/task.toml
@@ -45,6 +45,7 @@ timeout_sec = 2400.0
 timeout_sec = 600.0
 
 [verifier.env]
+AWS_REGION = "us-east-1"
 VPC_ID = "{{compute-and-data-ec2-vlf3847wf-us-east-1-VpcId}}"
 SUBNET_ID_1 = "{{compute-and-data-ec2-vlf3847wf-us-east-1-SubnetId1}}"
 SUBNET_ID_2 = "{{compute-and-data-ec2-vlf3847wf-us-east-1-SubnetId2}}"

--- a/tasks/compute-and-data/create-medialive-channel/task.toml
+++ b/tasks/compute-and-data/create-medialive-channel/task.toml
@@ -29,6 +29,9 @@ timeout_sec = 1200.0
 [verifier]
 timeout_sec = 360.0
 
+[verifier.env]
+AWS_REGION = "us-east-1"
+
 [post_invoke]
 timeout_sec = 360.0
 

--- a/tasks/compute-and-data/create-medialive-channel/tests/check.py
+++ b/tasks/compute-and-data/create-medialive-channel/tests/check.py
@@ -6,7 +6,7 @@ import boto3
 from botocore.exceptions import ClientError
 from rewardkit import criterion
 
-REGION = os.environ.get("AWS_DEFAULT_REGION", "us-east-1")
+REGION = os.environ.get("AWS_REGION", os.environ.get("AWS_DEFAULT_REGION", "us-east-1"))
 
 AGENT_OUTPUT_PATH = Path("/logs/agent/agent-output.json")
 AGENT_OUTPUT: dict = {}

--- a/tasks/compute-and-data/create-s3-bucket-with-config/task.toml
+++ b/tasks/compute-and-data/create-s3-bucket-with-config/task.toml
@@ -29,6 +29,9 @@ timeout_sec = 1200.0
 [verifier]
 timeout_sec = 360.0
 
+[verifier.env]
+AWS_REGION = "us-east-1"
+
 [post_invoke]
 timeout_sec = 360.0
 

--- a/tasks/compute-and-data/create-s3-bucket-with-config/tests/check.py
+++ b/tasks/compute-and-data/create-s3-bucket-with-config/tests/check.py
@@ -17,7 +17,7 @@ from rewardkit import criterion
 
 # ── Inputs ───────────────────────────────────────────────────────────────────
 
-REGION = os.environ.get("AWS_DEFAULT_REGION", "us-east-1")
+REGION = os.environ.get("AWS_REGION", os.environ.get("AWS_DEFAULT_REGION", "us-east-1"))
 
 AGENT_OUTPUT_PATH = Path("/logs/agent/agent-output.json")
 AGENT_OUTPUT: dict = {}

--- a/tasks/compute-and-data/create-s3-tables-with-compaction/task.toml
+++ b/tasks/compute-and-data/create-s3-tables-with-compaction/task.toml
@@ -29,6 +29,9 @@ timeout_sec = 2400.0
 [verifier]
 timeout_sec = 360.0
 
+[verifier.env]
+AWS_REGION = "us-east-1"
+
 [environment]
 build_timeout_sec = 1200.0
 cpus = 1

--- a/tasks/compute-and-data/create-s3-tables-with-compaction/tests/check.py
+++ b/tasks/compute-and-data/create-s3-tables-with-compaction/tests/check.py
@@ -8,7 +8,7 @@ import boto3
 from botocore.exceptions import ClientError
 from rewardkit import criterion
 
-REGION = os.environ.get("AWS_DEFAULT_REGION", "us-east-1")
+REGION = os.environ.get("AWS_REGION", os.environ.get("AWS_DEFAULT_REGION", "us-east-1"))
 
 AGENT_OUTPUT_PATH = Path("/logs/agent/agent-output.json")
 AGENT_OUTPUT: dict = {}

--- a/tasks/compute-and-data/create-vpc-valkey-dynamodb/task.toml
+++ b/tasks/compute-and-data/create-vpc-valkey-dynamodb/task.toml
@@ -32,6 +32,9 @@ timeout_sec = 1200.0
 [verifier]
 timeout_sec = 600.0
 
+[verifier.env]
+AWS_REGION = "us-east-1"
+
 [solution.env]
 AWS_DEFAULT_REGION = "us-east-1"
 

--- a/tasks/compute-and-data/create-vpc-valkey-dynamodb/tests/check.py
+++ b/tasks/compute-and-data/create-vpc-valkey-dynamodb/tests/check.py
@@ -8,7 +8,7 @@ import boto3
 from botocore.exceptions import ClientError
 from rewardkit import criterion
 
-REGION = os.environ.get("AWS_DEFAULT_REGION", "us-east-1")
+REGION = os.environ.get("AWS_REGION", os.environ.get("AWS_DEFAULT_REGION", "us-east-1"))
 AGENT_OUTPUT_PATH = Path("/logs/agent/agent-output.json")
 AGENT_OUTPUT: dict = {}
 if AGENT_OUTPUT_PATH.exists():

--- a/tasks/compute-and-data/deploy-ec2-instance-with-ebs/task.toml
+++ b/tasks/compute-and-data/deploy-ec2-instance-with-ebs/task.toml
@@ -30,6 +30,7 @@ timeout_sec = 1200.0
 timeout_sec = 360.0
 
 [verifier.env]
+AWS_REGION = "us-east-1"
 VOLUME_ID = "{{compute-and-data-ec2-ra5bh6w8u-us-east-1-EBSVolumeId}}"
 VPC_ID = "{{compute-and-data-ec2-ra5bh6w8u-us-east-1-VpcId}}"
 SUBNET_ID = "{{compute-and-data-ec2-ra5bh6w8u-us-east-1-SubnetId}}"
@@ -41,17 +42,17 @@ timeout_sec = 360.0
 
 [pre_invoke.env]
 VOLUME_ID = "{{compute-and-data-ec2-ra5bh6w8u-us-east-1-EBSVolumeId}}"
-AWS_DEFAULT_REGION = "us-east-1"
+AWS_REGION = "us-east-1"
 
 [post_invoke]
 timeout_sec = 360.0
 
 [post_invoke.env]
 VOLUME_ID = "{{compute-and-data-ec2-ra5bh6w8u-us-east-1-EBSVolumeId}}"
-AWS_DEFAULT_REGION = "us-east-1"
+AWS_REGION = "us-east-1"
 
 [solution.env]
-AWS_DEFAULT_REGION = "us-east-1"
+AWS_REGION = "us-east-1"
 VOLUME_ID = "{{compute-and-data-ec2-ra5bh6w8u-us-east-1-EBSVolumeId}}"
 SUBNET_ID = "{{compute-and-data-ec2-ra5bh6w8u-us-east-1-SubnetId}}"
 SECURITY_GROUP_ID = "{{compute-and-data-ec2-ra5bh6w8u-us-east-1-SecurityGroupId}}"

--- a/tasks/compute-and-data/ec2-image-builder-pipeline/task.toml
+++ b/tasks/compute-and-data/ec2-image-builder-pipeline/task.toml
@@ -42,6 +42,9 @@ timeout_sec = 4800.0
 [verifier]
 timeout_sec = 360.0
 
+[verifier.env]
+SCENARIO_REGIONS = "{{aws-bench-scenario-allowed-regions}}"
+
 [solution.env]
 AWS_DEFAULT_REGION = "us-east-1"
 

--- a/tasks/compute-and-data/ec2-image-builder-pipeline/tests/check.py
+++ b/tasks/compute-and-data/ec2-image-builder-pipeline/tests/check.py
@@ -15,7 +15,10 @@ import boto3
 from botocore.exceptions import ClientError
 from rewardkit import criterion
 
-REGION = os.environ.get("AWS_DEFAULT_REGION", "us-east-1")
+SCENARIO_REGIONS = [
+    r.strip() for r in os.environ.get("SCENARIO_REGIONS", "us-east-1").split(",")
+]
+REGION = SCENARIO_REGIONS[0]  # Primary region for backwards compat
 
 try:
     AGENT_OUTPUT = json.loads(Path("/logs/agent/agent-output.json").read_text())
@@ -28,19 +31,41 @@ PIPELINE_ARN = AGENT_OUTPUT.get("image_pipeline_arn") or ""
 REQUIRED_DISTRIBUTION_REGION = "us-east-2"
 
 
-def _imagebuilder():
-    return boto3.client("imagebuilder", region_name=REGION)
+def _imagebuilder(region=None):
+    return boto3.client("imagebuilder", region_name=region or REGION)
 
 
 def _get_pipeline() -> dict | None:
     """Fetch the pipeline. Returns the imagePipeline dict, or None on failure."""
     if not PIPELINE_ARN:
         return None
-    try:
-        resp = _imagebuilder().get_image_pipeline(imagePipelineArn=PIPELINE_ARN)
-    except ClientError:
+    for region in SCENARIO_REGIONS:
+        try:
+            resp = _imagebuilder(region).get_image_pipeline(
+                imagePipelineArn=PIPELINE_ARN
+            )
+        except ClientError:
+            continue
+        pipeline = resp.get("imagePipeline") or None
+        if pipeline:
+            return pipeline
+    return None
+
+
+def _get_pipeline_region() -> str | None:
+    """Find the region where the pipeline exists."""
+    if not PIPELINE_ARN:
         return None
-    return resp.get("imagePipeline") or None
+    for region in SCENARIO_REGIONS:
+        try:
+            resp = _imagebuilder(region).get_image_pipeline(
+                imagePipelineArn=PIPELINE_ARN
+            )
+            if resp.get("imagePipeline"):
+                return region
+        except ClientError:
+            continue
+    return None
 
 
 @criterion(description="agent wrote agent-output.json with all required keys")
@@ -73,8 +98,10 @@ def distribution_targets_us_east_2(workspace: Path) -> bool:
     dist_arn = pipeline.get("distributionConfigurationArn")
     if not dist_arn:
         return False
+    # Use the region where the pipeline was found
+    pipeline_region = _get_pipeline_region()
     try:
-        resp = _imagebuilder().get_distribution_configuration(
+        resp = _imagebuilder(pipeline_region).get_distribution_configuration(
             distributionConfigurationArn=dist_arn
         )
     except ClientError:
@@ -100,9 +127,12 @@ def launch_template_uses_pipeline_ami(workspace: Path) -> bool:
     if not pipeline_arn:
         return False
 
+    # Use the region where the pipeline was found
+    pipeline_region = _get_pipeline_region()
+
     # Collect AMI IDs produced by this specific pipeline
     try:
-        img_resp = _imagebuilder().list_image_pipeline_images(
+        img_resp = _imagebuilder(pipeline_region).list_image_pipeline_images(
             imagePipelineArn=pipeline_arn
         )
     except ClientError:
@@ -118,29 +148,30 @@ def launch_template_uses_pipeline_ami(workspace: Path) -> bool:
     if not pipeline_ami_ids:
         return False
 
-    # Check all launch templates for one that references a pipeline-produced AMI
-    ec2 = boto3.client("ec2", region_name=REGION)
-    try:
-        lt_resp = ec2.describe_launch_templates()
-    except ClientError:
-        return False
-
-    for lt in lt_resp.get("LaunchTemplates") or []:
-        lt_id = lt.get("LaunchTemplateId")
-        if not lt_id:
-            continue
+    # Check all launch templates across regions for one that references a pipeline-produced AMI
+    for region in SCENARIO_REGIONS:
+        ec2 = boto3.client("ec2", region_name=region)
         try:
-            ver_resp = ec2.describe_launch_template_versions(
-                LaunchTemplateId=lt_id, Versions=["$Default"]
-            )
+            lt_resp = ec2.describe_launch_templates()
         except ClientError:
             continue
-        versions = ver_resp.get("LaunchTemplateVersions") or []
-        if not versions:
-            continue
-        launch_data = versions[0].get("LaunchTemplateData") or {}
-        image_id = launch_data.get("ImageId")
-        if image_id and image_id in pipeline_ami_ids:
-            return True
+
+        for lt in lt_resp.get("LaunchTemplates") or []:
+            lt_id = lt.get("LaunchTemplateId")
+            if not lt_id:
+                continue
+            try:
+                ver_resp = ec2.describe_launch_template_versions(
+                    LaunchTemplateId=lt_id, Versions=["$Default"]
+                )
+            except ClientError:
+                continue
+            versions = ver_resp.get("LaunchTemplateVersions") or []
+            if not versions:
+                continue
+            launch_data = versions[0].get("LaunchTemplateData") or {}
+            image_id = launch_data.get("ImageId")
+            if image_id and image_id in pipeline_ami_ids:
+                return True
 
     return False

--- a/tasks/compute-and-data/expand-elasticsearch-cfn-template/task.toml
+++ b/tasks/compute-and-data/expand-elasticsearch-cfn-template/task.toml
@@ -30,6 +30,7 @@ timeout_sec = 1200.0
 timeout_sec = 360.0
 
 [verifier.env]
+AWS_REGION = "us-east-1"
 BUCKET_NAME = "{{compute-and-data-s3-dz8q7r549-us-east-1-BucketName}}"
 
 [pre_invoke]
@@ -38,11 +39,11 @@ timeout_sec = 300.0
 [pre_invoke.env]
 BUCKET_NAME = "{{compute-and-data-s3-dz8q7r549-us-east-1-BucketName}}"
 AWS_REGION = "us-east-1"
-AWS_DEFAULT_REGION = "us-east-1"
+AWS_REGION = "us-east-1"
 
 [solution.env]
 BUCKET_NAME = "{{compute-and-data-s3-dz8q7r549-us-east-1-BucketName}}"
-AWS_DEFAULT_REGION = "us-east-1"
+AWS_REGION = "us-east-1"
 TEMPLATE_KEY = "elasticsearch-template-multi.yaml"
 
 [post_invoke]
@@ -51,7 +52,7 @@ timeout_sec = 360.0
 [post_invoke.env]
 BUCKET_NAME = "{{compute-and-data-s3-dz8q7r549-us-east-1-BucketName}}"
 AWS_REGION = "us-east-1"
-AWS_DEFAULT_REGION = "us-east-1"
+AWS_REGION = "us-east-1"
 
 [environment]
 build_timeout_sec = 1200.0

--- a/tasks/compute-and-data/kinesis-flink-studio-realtime/task.toml
+++ b/tasks/compute-and-data/kinesis-flink-studio-realtime/task.toml
@@ -40,8 +40,11 @@ timeout_sec = 360.0
 # studio app exists and is Flink-runtime; stream identity is left to the
 # instruction prompt.
 
+[verifier.env]
+AWS_REGION = "us-east-1"
+
 [solution.env]
-AWS_DEFAULT_REGION = "us-east-1"
+AWS_REGION = "us-east-1"
 
 # --- Harbor standard ---
 [environment]

--- a/tasks/compute-and-data/manage-buckets-eks-sagemaker/task.toml
+++ b/tasks/compute-and-data/manage-buckets-eks-sagemaker/task.toml
@@ -34,6 +34,7 @@ timeout_sec = 1200.0
 timeout_sec = 360.0
 
 [verifier.env]
+AWS_REGION = "us-east-1"
 EXPECTED_BUCKETS_CSV = "{{compute-and-data-eks-gztvy25g1-us-east-1-S3BucketNames}}"
 EXPECTED_CLUSTER = "{{compute-and-data-eks-gztvy25g1-us-east-1-EksClusterName}}"
 
@@ -47,7 +48,7 @@ timeout_sec = 1200.0
 EXPECTED_BUCKETS_CSV = "{{compute-and-data-eks-gztvy25g1-us-east-1-S3BucketNames}}"
 EXPECTED_CLUSTER = "{{compute-and-data-eks-gztvy25g1-us-east-1-EksClusterName}}"
 AWS_REGION = "us-east-1"
-AWS_DEFAULT_REGION = "us-east-1"
+AWS_REGION = "us-east-1"
 
 # --- aws-bench extension --- post_invoke (rollback) runs after verification
 # Note: object-version deletion is irreversible, so post_invoke uninstalls the
@@ -59,10 +60,10 @@ timeout_sec = 1200.0
 EXPECTED_CLUSTER = "{{compute-and-data-eks-gztvy25g1-us-east-1-EksClusterName}}"
 EXPECTED_BUCKETS_CSV = "{{compute-and-data-eks-gztvy25g1-us-east-1-S3BucketNames}}"
 AWS_REGION = "us-east-1"
-AWS_DEFAULT_REGION = "us-east-1"
+AWS_REGION = "us-east-1"
 
 [solution.env]
-AWS_DEFAULT_REGION = "us-east-1"
+AWS_REGION = "us-east-1"
 EXPECTED_CLUSTER = "{{compute-and-data-eks-gztvy25g1-us-east-1-EksClusterName}}"
 EXPECTED_BUCKETS_CSV = "{{compute-and-data-eks-gztvy25g1-us-east-1-S3BucketNames}}"
 

--- a/tasks/compute-and-data/managed-ad-with-ldaps-and-resets/task.toml
+++ b/tasks/compute-and-data/managed-ad-with-ldaps-and-resets/task.toml
@@ -38,6 +38,9 @@ timeout_sec = 7200.0
 [verifier]
 timeout_sec = 720.0
 
+[verifier.env]
+AWS_REGION = "us-east-1"
+
 [solution.env]
 AWS_DEFAULT_REGION = "us-east-1"
 

--- a/tasks/compute-and-data/managed-ad-with-ldaps-and-resets/tests/check.py
+++ b/tasks/compute-and-data/managed-ad-with-ldaps-and-resets/tests/check.py
@@ -18,7 +18,7 @@ import boto3
 from botocore.exceptions import ClientError
 from rewardkit import criterion
 
-REGION = os.environ.get("AWS_DEFAULT_REGION", "us-east-1")
+REGION = os.environ.get("AWS_REGION", os.environ.get("AWS_DEFAULT_REGION", "us-east-1"))
 
 try:
     AGENT_OUTPUT = json.loads(Path("/logs/agent/agent-output.json").read_text())

--- a/tasks/compute-and-data/move-s3-contents-within-bucket/task.toml
+++ b/tasks/compute-and-data/move-s3-contents-within-bucket/task.toml
@@ -30,7 +30,7 @@ timeout_sec = 300.0
 [pre_invoke.env]
 MOVE_DATA_BUCKET = "{{compute-and-data-s3-oeimf302d-us-east-1-BucketName}}"
 AWS_REGION = "us-east-1"
-AWS_DEFAULT_REGION = "us-east-1"
+AWS_REGION = "us-east-1"
 
 [post_invoke]
 timeout_sec = 360.0
@@ -38,7 +38,7 @@ timeout_sec = 360.0
 [post_invoke.env]
 MOVE_DATA_BUCKET = "{{compute-and-data-s3-oeimf302d-us-east-1-BucketName}}"
 AWS_REGION = "us-east-1"
-AWS_DEFAULT_REGION = "us-east-1"
+AWS_REGION = "us-east-1"
 
 [agent]
 timeout_sec = 1200.0
@@ -47,12 +47,13 @@ timeout_sec = 1200.0
 timeout_sec = 360.0
 
 [verifier.env]
+AWS_REGION = "us-east-1"
 MOVE_DATA_BUCKET = "{{compute-and-data-s3-oeimf302d-us-east-1-BucketName}}"
 SOURCE_PATH = "{{compute-and-data-s3-oeimf302d-us-east-1-WrongSourceFolderPath}}"
 DESTINATION_PATH = "{{compute-and-data-s3-oeimf302d-us-east-1-DestinationFolderPath}}"
 
 [solution.env]
-AWS_DEFAULT_REGION = "us-east-1"
+AWS_REGION = "us-east-1"
 BUCKET_NAME = "{{compute-and-data-s3-oeimf302d-us-east-1-BucketName}}"
 DESTINATION_PATH = "{{compute-and-data-s3-oeimf302d-us-east-1-DestinationFolderPath}}"
 

--- a/tasks/compute-and-data/serverless-stripe-api-with-stream/task.toml
+++ b/tasks/compute-and-data/serverless-stripe-api-with-stream/task.toml
@@ -33,8 +33,11 @@ timeout_sec = 1200.0
 [verifier]
 timeout_sec = 360.0
 
+[verifier.env]
+AWS_REGION = "us-east-1"
+
 [solution.env]
-AWS_DEFAULT_REGION = "us-east-1"
+AWS_REGION = "us-east-1"
 TABLE_NAME = "visitor-ip-log"
 FUNCTION_NAME = "visitor-ip-capture"
 ROLE_NAME = "visitor-ip-lambda-role"

--- a/tasks/compute-and-data/sync-s3-buckets-with-metadata/task.toml
+++ b/tasks/compute-and-data/sync-s3-buckets-with-metadata/task.toml
@@ -30,6 +30,7 @@ timeout_sec = 1200.0
 timeout_sec = 360.0
 
 [verifier.env]
+AWS_REGION = "us-east-1"
 SYNC_SOURCE_BUCKET = "{{compute-and-data-s3-mnbh73950-us-east-1-SourceBucketName}}"
 DESTINATION_BUCKET = "{{compute-and-data-s3-mnbh73950-us-east-1-DestinationBucketName}}"
 
@@ -40,12 +41,12 @@ timeout_sec = 300.0
 SYNC_SOURCE_BUCKET = "{{compute-and-data-s3-mnbh73950-us-east-1-SourceBucketName}}"
 DESTINATION_BUCKET = "{{compute-and-data-s3-mnbh73950-us-east-1-DestinationBucketName}}"
 AWS_REGION = "us-east-1"
-AWS_DEFAULT_REGION = "us-east-1"
+AWS_REGION = "us-east-1"
 
 [solution.env]
 SYNC_SOURCE_BUCKET = "{{compute-and-data-s3-mnbh73950-us-east-1-SourceBucketName}}"
 DESTINATION_BUCKET = "{{compute-and-data-s3-mnbh73950-us-east-1-DestinationBucketName}}"
-AWS_DEFAULT_REGION = "us-east-1"
+AWS_REGION = "us-east-1"
 
 [post_invoke]
 timeout_sec = 360.0
@@ -54,7 +55,7 @@ timeout_sec = 360.0
 SYNC_SOURCE_BUCKET = "{{compute-and-data-s3-mnbh73950-us-east-1-SourceBucketName}}"
 DESTINATION_BUCKET = "{{compute-and-data-s3-mnbh73950-us-east-1-DestinationBucketName}}"
 AWS_REGION = "us-east-1"
-AWS_DEFAULT_REGION = "us-east-1"
+AWS_REGION = "us-east-1"
 
 [environment]
 build_timeout_sec = 1200.0

--- a/tasks/streaming-and-iot/connect-create-customer-profiles/task.toml
+++ b/tasks/streaming-and-iot/connect-create-customer-profiles/task.toml
@@ -50,12 +50,13 @@ timeout_sec = 1200.0
 timeout_sec = 240.0
 
 [verifier.env]
+AWS_REGION = "us-east-1"
 DOMAIN_NAME = "{{streaming-and-iot-connect-cnp4r8t2k-us-east-1-ProfilesDomainName}}"
 ACCOUNT_ID_1 = "{{streaming-and-iot-connect-cnp4r8t2k-us-east-1-AccountId1}}"
 ACCOUNT_ID_2 = "{{streaming-and-iot-connect-cnp4r8t2k-us-east-1-AccountId2}}"
 
 [solution.env]
-AWS_DEFAULT_REGION = "us-east-1"
+AWS_REGION = "us-east-1"
 DOMAIN_NAME = "{{streaming-and-iot-connect-cnp4r8t2k-us-east-1-ProfilesDomainName}}"
 ACCOUNT_ID_1 = "{{streaming-and-iot-connect-cnp4r8t2k-us-east-1-AccountId1}}"
 ACCOUNT_ID_2 = "{{streaming-and-iot-connect-cnp4r8t2k-us-east-1-AccountId2}}"

--- a/tasks/streaming-and-iot/health-eventbridge-csv-export/task.toml
+++ b/tasks/streaming-and-iot/health-eventbridge-csv-export/task.toml
@@ -50,12 +50,13 @@ timeout_sec = 1800.0
 timeout_sec = 720.0
 
 [verifier.env]
+AWS_REGION = "us-east-1"
 EVENT_BUS_NAME = "{{streaming-and-iot-eventbridge-evbhx72k1-us-east-1-EventBusName}}"
 EXPORT_BUCKET = "{{streaming-and-iot-eventbridge-evbhx72k1-us-east-1-ExportBucketName}}"
 HEALTH_ROLE_NAME = "{{streaming-and-iot-eventbridge-evbhx72k1-us-east-1-HealthRoleName}}"
 
 [solution.env]
-AWS_DEFAULT_REGION = "us-east-1"
+AWS_REGION = "us-east-1"
 EVENT_BUS_NAME = "{{streaming-and-iot-eventbridge-evbhx72k1-us-east-1-EventBusName}}"
 EXPORT_BUCKET = "{{streaming-and-iot-eventbridge-evbhx72k1-us-east-1-ExportBucketName}}"
 HEALTH_ROLE_NAME = "{{streaming-and-iot-eventbridge-evbhx72k1-us-east-1-HealthRoleName}}"

--- a/tasks/streaming-and-iot/kds-firehose-iceberg-athena/task.toml
+++ b/tasks/streaming-and-iot/kds-firehose-iceberg-athena/task.toml
@@ -45,12 +45,13 @@ timeout_sec = 2400.0
 timeout_sec = 1440.0
 
 [verifier.env]
+AWS_REGION = "us-east-1"
 KINESIS_STREAM_NAME = "{{streaming-and-iot-kinesis-kdsicb52e-us-east-1-KinesisStreamName}}"
 S3_SINK_BUCKET = "{{streaming-and-iot-kinesis-kdsicb52e-us-east-1-S3BucketName}}"
 FIREHOSE_ROLE_NAME = "{{streaming-and-iot-kinesis-kdsicb52e-us-east-1-FirehoseRoleName}}"
 
 [solution.env]
-AWS_DEFAULT_REGION = "us-east-1"
+AWS_REGION = "us-east-1"
 KINESIS_STREAM_NAME = "{{streaming-and-iot-kinesis-kdsicb52e-us-east-1-KinesisStreamName}}"
 S3_SINK_BUCKET = "{{streaming-and-iot-kinesis-kdsicb52e-us-east-1-S3BucketName}}"
 FIREHOSE_ROLE_NAME = "{{streaming-and-iot-kinesis-kdsicb52e-us-east-1-FirehoseRoleName}}"

--- a/tasks/streaming-and-iot/neptune-bulk-load-and-shortest-path/task.toml
+++ b/tasks/streaming-and-iot/neptune-bulk-load-and-shortest-path/task.toml
@@ -48,6 +48,7 @@ timeout_sec = 3000.0
 timeout_sec = 600.0
 
 [verifier.env]
+AWS_REGION = "us-east-1"
 NEPTUNE_CLUSTER_ID = "{{streaming-and-iot-neptune-npt5d8h2v-us-east-1-NeptuneClusterId}}"
 NEPTUNE_ENDPOINT = "{{streaming-and-iot-neptune-npt5d8h2v-us-east-1-NeptuneEndpoint}}"
 LOADER_BUCKET = "{{streaming-and-iot-neptune-npt5d8h2v-us-east-1-LoaderBucketName}}"
@@ -55,7 +56,7 @@ LOADER_ROLE_ARN = "{{streaming-and-iot-neptune-npt5d8h2v-us-east-1-LoaderRoleArn
 BRIDGE_LAMBDA_NAME = "{{streaming-and-iot-neptune-npt5d8h2v-us-east-1-BridgeLambdaName}}"
 
 [solution.env]
-AWS_DEFAULT_REGION = "us-east-1"
+AWS_REGION = "us-east-1"
 BRIDGE_LAMBDA_NAME = "{{streaming-and-iot-neptune-npt5d8h2v-us-east-1-BridgeLambdaName}}"
 LOADER_BUCKET = "{{streaming-and-iot-neptune-npt5d8h2v-us-east-1-LoaderBucketName}}"
 LOADER_ROLE_ARN = "{{streaming-and-iot-neptune-npt5d8h2v-us-east-1-LoaderRoleArn}}"


### PR DESCRIPTION
Two categories of fixes:

1. **Tasks with us-east-1 in instruction (12 task.toml):** Add `AWS_DEFAULT_REGION = "us-east-1"` to `[verifier.env]` for tasks that were missing it. check.py already reads this env var.

2. **Tasks without region in instruction (7 check.py + 7 task.toml):** Update check.py to iterate over `SCENARIO_REGIONS` instead of checking a single hardcoded region. The agent is SCP-restricted to scenario regions, so if it creates resources in us-east-2 instead of us-east-1, the verifier now finds them.

Testing:
- `make ready` passes (28/28)
- Manual e2e: created MediaLive input in us-east-2 on deployed account, confirmed multi-region iteration found it (would have failed without this fix)