### PR TITLE
Remove incidental public EC2 IPs

### DIFF
--- a/scenarios/compute-and-data/scenario/cdk_app/stacks/ec2/ec2_ydhdiehs5.ts
+++ b/scenarios/compute-and-data/scenario/cdk_app/stacks/ec2/ec2_ydhdiehs5.ts
@@ -87,6 +87,7 @@ export class ec2_ydhdiehs5 extends cdk.Stack {
         // Transit EC2 Instance
         const transitInstance = new ec2.Instance(this, 'TransitInstance', {
             vpc: transitVpc,
+            associatePublicIpAddress: false,
             instanceType: new ec2.InstanceType('t3.medium'),
             machineImage: ec2.MachineImage.latestAmazonLinux2023(),
             securityGroup: transitSG,

--- a/scenarios/ec2-multiregion/scenario/cdk_app/stacks/ec2_ks84v1fh1.ts
+++ b/scenarios/ec2-multiregion/scenario/cdk_app/stacks/ec2_ks84v1fh1.ts
@@ -191,6 +191,7 @@ export class EC2_ks84v1fh12 extends cdk.Stack {
         // Create the EC2 instance
         const defaultVpcInstance = new ec2.Instance(this, 'MyEC2Instance', {
             vpc: defaultVpc,
+            associatePublicIpAddress: false,
             vpcSubnets: {
                 subnetType: ec2.SubnetType.PUBLIC, // Choose public subnet
             },

--- a/scenarios/ec2-multiregion/scenario/cdk_app/stacks/ec2_ls9fuhb52.ts
+++ b/scenarios/ec2-multiregion/scenario/cdk_app/stacks/ec2_ls9fuhb52.ts
@@ -38,6 +38,7 @@ export class EC2_ls9fuhb522 extends cdk.Stack {
         // Create EC2 Instance
         const instance = new ec2.Instance(this, 'WebServerInstance', {
             vpc,
+            associatePublicIpAddress: false,
             vpcSubnets: {
                 subnetType: ec2.SubnetType.PUBLIC,
             },

--- a/scenarios/reference-architectures/scenario/cdk_app/stacks/ssm/ssm_document_association.ts
+++ b/scenarios/reference-architectures/scenario/cdk_app/stacks/ssm/ssm_document_association.ts
@@ -14,7 +14,7 @@ import { StackUtils } from '../../lib/shared';
  * that periodically creates timestamped files.
  *
  * Resources created:
- * 1. VPC (1 AZ, no NAT, public subnets only)
+ * 1. VPC (1 AZ, no NAT, private subnet with SSM endpoints)
  * 2. IAM Role for EC2 with AmazonSSMManagedInstanceCore
  * 3. EC2 Instance (t3.nano, Amazon Linux 2023) tagged Environment=Development
  * 4. SSM Document (Command type) with shell script
@@ -25,7 +25,7 @@ export class SsmDocumentAssociation extends cdk.Stack {
     constructor(scope: Construct, id: string, props: cdk.StackProps) {
         super(scope, id, props);
 
-        // VPC: 1 AZ, no NAT, public subnets only
+        // VPC: 1 AZ, no NAT, private subnet with SSM endpoints
         const vpc = new ec2.Vpc(this, 'SsmVpc', {
             vpcName: `SsmDocAssocVpc-${this.account}-${this.region}`,
             maxAzs: 1,
@@ -33,12 +33,22 @@ export class SsmDocumentAssociation extends cdk.Stack {
             subnetConfiguration: [
                 {
                     cidrMask: 24,
-                    name: 'Public',
-                    subnetType: ec2.SubnetType.PUBLIC,
+                    name: 'Private',
+                    subnetType: ec2.SubnetType.PRIVATE_ISOLATED,
                 },
             ],
         });
         vpc.applyRemovalPolicy(cdk.RemovalPolicy.DESTROY);
+
+        vpc.addInterfaceEndpoint('SsmEndpoint', {
+            service: ec2.InterfaceVpcEndpointAwsService.SSM,
+        });
+        vpc.addInterfaceEndpoint('SsmMessagesEndpoint', {
+            service: ec2.InterfaceVpcEndpointAwsService.SSM_MESSAGES,
+        });
+        vpc.addInterfaceEndpoint('Ec2MessagesEndpoint', {
+            service: ec2.InterfaceVpcEndpointAwsService.EC2_MESSAGES,
+        });
 
         // IAM Role for EC2 with SSM managed policy
         const role = new iam.Role(this, 'SsmInstanceRole', {
@@ -57,7 +67,7 @@ export class SsmDocumentAssociation extends cdk.Stack {
             instanceType: ec2.InstanceType.of(ec2.InstanceClass.T3, ec2.InstanceSize.NANO),
             machineImage: ec2.MachineImage.latestAmazonLinux2023(),
             instanceName: `SsmDocAssocInstance-${this.account}-${this.region}`,
-            vpcSubnets: { subnetType: ec2.SubnetType.PUBLIC },
+            vpcSubnets: { subnetType: ec2.SubnetType.PRIVATE_ISOLATED },
             requireImdsv2: true,
         });
         instance.applyRemovalPolicy(cdk.RemovalPolicy.DESTROY);

--- a/scenarios/serverless-apps/scenario/cdk_app/stacks/compute_ec2.ts
+++ b/scenarios/serverless-apps/scenario/cdk_app/stacks/compute_ec2.ts
@@ -41,7 +41,7 @@ export class ComputeEc2Stack extends cdk.Stack {
 
         // Create EC2 instance with IMDSv2 and tags using launch template
         const instance = new ec2.CfnInstance(this, 'TestInstance', {
-            subnetId: vpc.publicSubnets[0].subnetId,
+            subnetId: vpc.privateSubnets[0].subnetId,
             iamInstanceProfile: instanceProfile.ref,
             launchTemplate: {
                 launchTemplateId: launchTemplate.ref,

--- a/scenarios/troubleshooting-multiservice/scenario/cdk_app/stacks/ec2/ec2_67wz6v9zc.ts
+++ b/scenarios/troubleshooting-multiservice/scenario/cdk_app/stacks/ec2/ec2_67wz6v9zc.ts
@@ -42,8 +42,8 @@ export class Ec2_67wz6v9zc extends DeploymentStack {
             ],
         });
 
-        // Get the public subnet in us-east-1c (or first available)
-        const publicSubnet = vpc.publicSubnets[0];
+        // Keep the jump server private; no task depends on direct internet access.
+        const jumpServerSubnet = vpc.isolatedSubnets[0];
 
         // Create security group for RDS (referenced by jump server SG)
         const rdsSecurityGroup = new ec2.SecurityGroup(this, 'QaRdsSg', {
@@ -87,13 +87,13 @@ export class Ec2_67wz6v9zc extends DeploymentStack {
             instanceName: `qa-rds-jump-server-${this.account}-${this.region}`,
             vpc,
             vpcSubnets: {
-                subnets: [publicSubnet],
+                subnets: [jumpServerSubnet],
             },
             instanceType: ec2.InstanceType.of(ec2.InstanceClass.T3, ec2.InstanceSize.MICRO),
             machineImage: ec2.MachineImage.latestAmazonLinux2023(),
             securityGroup: jumpServerSg,
             role: instanceRole,
-            associatePublicIpAddress: true,
+            associatePublicIpAddress: false,
             blockDevices: [
                 {
                     deviceName: '/dev/xvda',
@@ -153,14 +153,14 @@ export class Ec2_67wz6v9zc extends DeploymentStack {
 
         // Add tags
         cdk.Tags.of(vpc).add('Name', 'garnet-qa-vpc');
-        cdk.Tags.of(publicSubnet).add('Name', 'garnet-qa-vpc-public-subnet-01');
-        cdk.Tags.of(publicSubnet).add('env', 'qa');
+        cdk.Tags.of(jumpServerSubnet).add('Name', 'garnet-qa-vpc-private-subnet-01');
+        cdk.Tags.of(jumpServerSubnet).add('env', 'qa');
         cdk.Tags.of(jumpServer).add('Name', 'qa-rds-jump-server');
         cdk.Tags.of(jumpServerSg).add('Name', 'garnet-qa-rds-jump-server-sg');
 
         // Export stack outputs
         StackUtils.exportStack(this, 'VpcId', vpc.vpcId, 'The ID of the QA VPC');
-        StackUtils.exportStack(this, 'PublicSubnetId', publicSubnet.subnetId, 'The ID of the public subnet');
+        StackUtils.exportStack(this, 'PublicSubnetId', jumpServerSubnet.subnetId, 'The ID of the jump server subnet');
         StackUtils.exportStack(
             this,
             'JumpServerInstanceId',


### PR DESCRIPTION
## What changed

- Remove public IP assignment from unused/support EC2 fixtures.
- Keep ec2-multiregion instances in public subnets for inventory tasks while disabling public IPs on the three instances that are not expected to be internet-SSH-reachable.
- Move the reference SSM document-association instance into a private subnet with SSM VPC endpoints.

## Why

Repeated benchmark runs produced public-EC2 findings for fixtures whose public reachability is not part of any task. These changes preserve the existing task topology and expected answers while avoiding incidental public exposure.

The two ec2-multiregion instances explicitly required by the SSH-reachability task are intentionally unchanged.

## Validation

- make cdk
- make check
- git diff --check

No task instructions, task metadata, verifiers, or ground truths were changed.
