### PR TITLE
Run helper workloads without public IPs

### DIFF
--- a/scenarios/streaming-and-iot/scenario/cdk_app/stacks/ecs/ecs_ecsasg7m4.ts
+++ b/scenarios/streaming-and-iot/scenario/cdk_app/stacks/ecs/ecs_ecsasg7m4.ts
@@ -25,10 +25,10 @@ export class ecs_ecsasg7m4 extends cdk.Stack {
         const vpc = new ec2.Vpc(this, 'EcsVpc', {
             ipAddresses: ec2.IpAddresses.cidr('10.50.0.0/16'),
             maxAzs: 2,
-            natGateways: 0,
+            natGateways: 1,
             subnetConfiguration: [
                 { name: 'public', subnetType: ec2.SubnetType.PUBLIC, cidrMask: 24 },
-                { name: 'private', subnetType: ec2.SubnetType.PRIVATE_ISOLATED, cidrMask: 24 },
+                { name: 'private', subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS, cidrMask: 24 },
             ],
             restrictDefaultSecurityGroup: false,
         });
@@ -57,6 +57,7 @@ export class ecs_ecsasg7m4 extends cdk.Stack {
             instanceType: ec2.InstanceType.of(ec2.InstanceClass.T3, ec2.InstanceSize.MICRO),
             machineImage: ecs.EcsOptimizedImage.amazonLinux2023(),
             role: instanceRole,
+            requireImdsv2: true,
             securityGroup: new ec2.SecurityGroup(this, 'EcsInstanceSg', {
                 vpc,
                 allowAllOutbound: true,
@@ -69,7 +70,7 @@ export class ecs_ecsasg7m4 extends cdk.Stack {
         const asg = new autoscaling.AutoScalingGroup(this, 'EcsAsg', {
             autoScalingGroupName: `bench-asg-${this.account.slice(-6)}`,
             vpc,
-            vpcSubnets: { subnetType: ec2.SubnetType.PUBLIC },
+            vpcSubnets: { subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS },
             launchTemplate,
             minCapacity: 1,
             maxCapacity: 1,

--- a/scenarios/troubleshooting-multiservice/scenario/cdk_app/stacks/ec2/ec2_pg4rychx0.ts
+++ b/scenarios/troubleshooting-multiservice/scenario/cdk_app/stacks/ec2/ec2_pg4rychx0.ts
@@ -38,7 +38,8 @@ export class Ec2_pg4rychx0 extends cdk.Stack {
 
         this.accountId = this.account;
 
-        // Create VPC for Helper Network
+        // Create a private VPC for the helper instance. Interface endpoints
+        // preserve the intended Secrets Manager/KMS path without a public IP.
         const helperVpc = new ec2.Vpc(this, 'HelperVPC', {
             vpcName: `helper-vpc-${this.account}-${this.region}`,
             ipAddresses: ec2.IpAddresses.cidr('172.25.0.0/16'),
@@ -47,7 +48,7 @@ export class Ec2_pg4rychx0 extends cdk.Stack {
             subnetConfiguration: [
                 {
                     name: 'HelperPrimary',
-                    subnetType: ec2.SubnetType.PUBLIC,
+                    subnetType: ec2.SubnetType.PRIVATE_ISOLATED,
                     cidrMask: 23,
                 },
             ],
@@ -62,15 +63,31 @@ export class Ec2_pg4rychx0 extends cdk.Stack {
             subnetConfiguration: [
                 {
                     name: 'CustomerSecondary',
-                    subnetType: ec2.SubnetType.PUBLIC,
+                    subnetType: ec2.SubnetType.PRIVATE_ISOLATED,
                     cidrMask: 16,
                 },
             ],
         });
 
         // Get the subnets
-        const helperSubnet = helperVpc.publicSubnets[0];
-        const customerSubnet = customerVpc.publicSubnets[0];
+        const helperSubnet = helperVpc.isolatedSubnets[0];
+        const customerSubnet = customerVpc.isolatedSubnets[0];
+
+        helperVpc.addInterfaceEndpoint('SecretsManagerEndpoint', {
+            service: ec2.InterfaceVpcEndpointAwsService.SECRETS_MANAGER,
+        });
+        helperVpc.addInterfaceEndpoint('KmsEndpoint', {
+            service: ec2.InterfaceVpcEndpointAwsService.KMS,
+        });
+        helperVpc.addInterfaceEndpoint('SsmEndpoint', {
+            service: ec2.InterfaceVpcEndpointAwsService.SSM,
+        });
+        helperVpc.addInterfaceEndpoint('SsmMessagesEndpoint', {
+            service: ec2.InterfaceVpcEndpointAwsService.SSM_MESSAGES,
+        });
+        helperVpc.addInterfaceEndpoint('Ec2MessagesEndpoint', {
+            service: ec2.InterfaceVpcEndpointAwsService.EC2_MESSAGES,
+        });
 
         // Create Security Group for Helper VPC
         const helperSecurityGroup = new ec2.SecurityGroup(this, 'HelperSecurityGroup', {

--- a/scenarios/troubleshooting-multiservice/scenario/cdk_app/stacks/sagemaker/sagemaker_vszf4yl62.ts
+++ b/scenarios/troubleshooting-multiservice/scenario/cdk_app/stacks/sagemaker/sagemaker_vszf4yl62.ts
@@ -37,7 +37,7 @@ export class Sagemaker_vszf4yl62 extends cdk.Stack {
                 {
                     cidrMask: 23,
                     name: 'HelperSubnet',
-                    subnetType: ec2.SubnetType.PUBLIC,
+                    subnetType: ec2.SubnetType.PRIVATE_ISOLATED,
                 },
             ],
         });
@@ -51,14 +51,14 @@ export class Sagemaker_vszf4yl62 extends cdk.Stack {
                 {
                     cidrMask: 20,
                     name: 'WorkloadSubnet',
-                    subnetType: ec2.SubnetType.PUBLIC,
+                    subnetType: ec2.SubnetType.PRIVATE_ISOLATED,
                 },
             ],
         });
 
         // Get the subnets
-        const helperSubnet = helperVpc.publicSubnets[0];
-        const workloadSubnet = workloadVpc.publicSubnets[0];
+        const helperSubnet = helperVpc.isolatedSubnets[0];
+        const workloadSubnet = workloadVpc.isolatedSubnets[0];
 
         // Create Helper Security Group
         const helperSecurityGroup = new ec2.SecurityGroup(this, 'HelperSecurityGroup', {
@@ -90,6 +90,7 @@ export class Sagemaker_vszf4yl62 extends cdk.Stack {
         // Shortened name to comply with 32-char AWS limit (26 chars)
         const nlb = new elbv2.NetworkLoadBalancer(this, 'HyperPodNLB', {
             vpc: helperVpc,
+            vpcSubnets: { subnets: [helperSubnet] },
             internetFacing: false,
             loadBalancerName: 'NLB-cluster1-group1',
         });


### PR DESCRIPTION
## What changed

- Move the Quartz helper ASG into private isolated subnets while preserving its internal NLB health-check failure loop.
- Run the streaming ECS-on-EC2 capacity in private-with-egress subnets and require IMDSv2.
- Move the Secrets Manager troubleshooting helper into private isolated subnets with Secrets Manager, KMS, and SSM VPC endpoints.

## Why

These workloads need running EC2 instances, but none of their tasks require public EC2 IPs. Private connectivity preserves the intended task behavior while avoiding repeated public-IP findings.

The intentional misconfigurations under test are unchanged:

- Quartz helper SG still blocks internal NLB health checks.
- Streaming task still has EC2-backed ECS capacity for the agent to use.
- Secrets Manager helper role still lacks kms:Decrypt.

## Validation

- make cdk
- make check
- git diff --check

No task instructions, task metadata, verifiers, or ground truths were changed.
