### PR TITLE
fix(verifier): retry rewardkit judge call on transient Bedrock errors

### DIFF
--- a/shared/judge/test.sh
+++ b/shared/judge/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/shared/judge/test.sh
+++ b/shared/judge/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'

--- a/tasks/api-and-observability/bedrock-agentcore-runtime-missing-logs/tests/test.sh
+++ b/tasks/api-and-observability/bedrock-agentcore-runtime-missing-logs/tests/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/tasks/api-and-observability/bedrock-agentcore-runtime-missing-logs/tests/test.sh
+++ b/tasks/api-and-observability/bedrock-agentcore-runtime-missing-logs/tests/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'

--- a/tasks/api-and-observability/bedrock-kb-embedding-model-cfn-deps/tests/test.sh
+++ b/tasks/api-and-observability/bedrock-kb-embedding-model-cfn-deps/tests/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/tasks/api-and-observability/bedrock-kb-embedding-model-cfn-deps/tests/test.sh
+++ b/tasks/api-and-observability/bedrock-kb-embedding-model-cfn-deps/tests/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'

--- a/tasks/api-and-observability/cloudfront-distribution-origin-error-diagnosis/tests/test.sh
+++ b/tasks/api-and-observability/cloudfront-distribution-origin-error-diagnosis/tests/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/tasks/api-and-observability/cloudfront-distribution-origin-error-diagnosis/tests/test.sh
+++ b/tasks/api-and-observability/cloudfront-distribution-origin-error-diagnosis/tests/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'

--- a/tasks/api-and-observability/cloudfront-oac-s-forbidden-troubleshoot/tests/test.sh
+++ b/tasks/api-and-observability/cloudfront-oac-s-forbidden-troubleshoot/tests/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/tasks/api-and-observability/cloudfront-oac-s-forbidden-troubleshoot/tests/test.sh
+++ b/tasks/api-and-observability/cloudfront-oac-s-forbidden-troubleshoot/tests/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'

--- a/tasks/api-and-observability/debug-api-gateway-iam-authorization/tests/test.sh
+++ b/tasks/api-and-observability/debug-api-gateway-iam-authorization/tests/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/tasks/api-and-observability/debug-api-gateway-iam-authorization/tests/test.sh
+++ b/tasks/api-and-observability/debug-api-gateway-iam-authorization/tests/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'

--- a/tasks/api-and-observability/debug-websocket-api-backend-response/tests/test.sh
+++ b/tasks/api-and-observability/debug-websocket-api-backend-response/tests/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/tasks/api-and-observability/debug-websocket-api-backend-response/tests/test.sh
+++ b/tasks/api-and-observability/debug-websocket-api-backend-response/tests/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'

--- a/tasks/api-and-observability/diagnose-alb-five-xx-errors/tests/test.sh
+++ b/tasks/api-and-observability/diagnose-alb-five-xx-errors/tests/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/tasks/api-and-observability/diagnose-alb-five-xx-errors/tests/test.sh
+++ b/tasks/api-and-observability/diagnose-alb-five-xx-errors/tests/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'

--- a/tasks/api-and-observability/diagnose-alb-opensearch-bad-gateway/tests/test.sh
+++ b/tasks/api-and-observability/diagnose-alb-opensearch-bad-gateway/tests/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/tasks/api-and-observability/diagnose-alb-opensearch-bad-gateway/tests/test.sh
+++ b/tasks/api-and-observability/diagnose-alb-opensearch-bad-gateway/tests/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'

--- a/tasks/api-and-observability/diagnose-cloudwatch-alarm-firing/tests/test.sh
+++ b/tasks/api-and-observability/diagnose-cloudwatch-alarm-firing/tests/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/tasks/api-and-observability/diagnose-cloudwatch-alarm-firing/tests/test.sh
+++ b/tasks/api-and-observability/diagnose-cloudwatch-alarm-firing/tests/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'

--- a/tasks/api-and-observability/diagnose-onyx-lambda-processing-failure/tests/test.sh
+++ b/tasks/api-and-observability/diagnose-onyx-lambda-processing-failure/tests/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/tasks/api-and-observability/diagnose-onyx-lambda-processing-failure/tests/test.sh
+++ b/tasks/api-and-observability/diagnose-onyx-lambda-processing-failure/tests/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'

--- a/tasks/api-and-observability/diagnose-xray-service-latency-cause/tests/test.sh
+++ b/tasks/api-and-observability/diagnose-xray-service-latency-cause/tests/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/tasks/api-and-observability/diagnose-xray-service-latency-cause/tests/test.sh
+++ b/tasks/api-and-observability/diagnose-xray-service-latency-cause/tests/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'

--- a/tasks/api-and-observability/find-missing-step-functions-state-machine/tests/test.sh
+++ b/tasks/api-and-observability/find-missing-step-functions-state-machine/tests/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/tasks/api-and-observability/find-missing-step-functions-state-machine/tests/test.sh
+++ b/tasks/api-and-observability/find-missing-step-functions-state-machine/tests/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'

--- a/tasks/api-and-observability/lambda-sqs-reconciliation-no-output/tests/test.sh
+++ b/tasks/api-and-observability/lambda-sqs-reconciliation-no-output/tests/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/tasks/api-and-observability/lambda-sqs-reconciliation-no-output/tests/test.sh
+++ b/tasks/api-and-observability/lambda-sqs-reconciliation-no-output/tests/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'

--- a/tasks/api-and-observability/opensearch-check-document-request-status-logs/tests/test.sh
+++ b/tasks/api-and-observability/opensearch-check-document-request-status-logs/tests/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/tasks/api-and-observability/opensearch-check-document-request-status-logs/tests/test.sh
+++ b/tasks/api-and-observability/opensearch-check-document-request-status-logs/tests/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'

--- a/tasks/api-and-observability/opensearch-cognito-alb-timeout-diagnosis/tests/test.sh
+++ b/tasks/api-and-observability/opensearch-cognito-alb-timeout-diagnosis/tests/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/tasks/api-and-observability/opensearch-cognito-alb-timeout-diagnosis/tests/test.sh
+++ b/tasks/api-and-observability/opensearch-cognito-alb-timeout-diagnosis/tests/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'

--- a/tasks/databases-and-storage/analyze-s-intelligent-tiering-configs/tests/test.sh
+++ b/tasks/databases-and-storage/analyze-s-intelligent-tiering-configs/tests/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/tasks/databases-and-storage/analyze-s-intelligent-tiering-configs/tests/test.sh
+++ b/tasks/databases-and-storage/analyze-s-intelligent-tiering-configs/tests/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'

--- a/tasks/databases-and-storage/check-codebuild-project-nodejs-version/tests/test.sh
+++ b/tasks/databases-and-storage/check-codebuild-project-nodejs-version/tests/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/tasks/databases-and-storage/check-codebuild-project-nodejs-version/tests/test.sh
+++ b/tasks/databases-and-storage/check-codebuild-project-nodejs-version/tests/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'

--- a/tasks/databases-and-storage/check-s-bucket-access-profiles/tests/test.sh
+++ b/tasks/databases-and-storage/check-s-bucket-access-profiles/tests/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/tasks/databases-and-storage/check-s-bucket-access-profiles/tests/test.sh
+++ b/tasks/databases-and-storage/check-s-bucket-access-profiles/tests/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'

--- a/tasks/databases-and-storage/check-s-vector-bucket-indexes-exist/tests/test.sh
+++ b/tasks/databases-and-storage/check-s-vector-bucket-indexes-exist/tests/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/tasks/databases-and-storage/check-s-vector-bucket-indexes-exist/tests/test.sh
+++ b/tasks/databases-and-storage/check-s-vector-bucket-indexes-exist/tests/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'

--- a/tasks/databases-and-storage/cloudformation-top-stacks-resource-breakdown/tests/test.sh
+++ b/tasks/databases-and-storage/cloudformation-top-stacks-resource-breakdown/tests/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/tasks/databases-and-storage/cloudformation-top-stacks-resource-breakdown/tests/test.sh
+++ b/tasks/databases-and-storage/cloudformation-top-stacks-resource-breakdown/tests/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'

--- a/tasks/databases-and-storage/compare-s-bucket-structure-sizes/tests/test.sh
+++ b/tasks/databases-and-storage/compare-s-bucket-structure-sizes/tests/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/tasks/databases-and-storage/compare-s-bucket-structure-sizes/tests/test.sh
+++ b/tasks/databases-and-storage/compare-s-bucket-structure-sizes/tests/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'

--- a/tasks/databases-and-storage/count-cfn-stacks-with-s-buckets/tests/test.sh
+++ b/tasks/databases-and-storage/count-cfn-stacks-with-s-buckets/tests/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/tasks/databases-and-storage/count-cfn-stacks-with-s-buckets/tests/test.sh
+++ b/tasks/databases-and-storage/count-cfn-stacks-with-s-buckets/tests/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'

--- a/tasks/databases-and-storage/count-old-s-buckets/tests/test.sh
+++ b/tasks/databases-and-storage/count-old-s-buckets/tests/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/tasks/databases-and-storage/count-old-s-buckets/tests/test.sh
+++ b/tasks/databases-and-storage/count-old-s-buckets/tests/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'

--- a/tasks/databases-and-storage/count-sns-topic-sqs-subscribers/tests/test.sh
+++ b/tasks/databases-and-storage/count-sns-topic-sqs-subscribers/tests/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/tasks/databases-and-storage/count-sns-topic-sqs-subscribers/tests/test.sh
+++ b/tasks/databases-and-storage/count-sns-topic-sqs-subscribers/tests/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'

--- a/tasks/databases-and-storage/count-windows-server-managed-nodes/tests/test.sh
+++ b/tasks/databases-and-storage/count-windows-server-managed-nodes/tests/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/tasks/databases-and-storage/count-windows-server-managed-nodes/tests/test.sh
+++ b/tasks/databases-and-storage/count-windows-server-managed-nodes/tests/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'

--- a/tasks/databases-and-storage/dynamodb-query-workflow-status-analysis/tests/test.sh
+++ b/tasks/databases-and-storage/dynamodb-query-workflow-status-analysis/tests/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/tasks/databases-and-storage/dynamodb-query-workflow-status-analysis/tests/test.sh
+++ b/tasks/databases-and-storage/dynamodb-query-workflow-status-analysis/tests/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'

--- a/tasks/databases-and-storage/dynamodb-scan-and-fetch-record/tests/test.sh
+++ b/tasks/databases-and-storage/dynamodb-scan-and-fetch-record/tests/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/tasks/databases-and-storage/dynamodb-scan-and-fetch-record/tests/test.sh
+++ b/tasks/databases-and-storage/dynamodb-scan-and-fetch-record/tests/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'

--- a/tasks/databases-and-storage/dynamodb-scan-filter-by-attribute/tests/test.sh
+++ b/tasks/databases-and-storage/dynamodb-scan-filter-by-attribute/tests/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/tasks/databases-and-storage/dynamodb-scan-filter-by-attribute/tests/test.sh
+++ b/tasks/databases-and-storage/dynamodb-scan-filter-by-attribute/tests/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'

--- a/tasks/databases-and-storage/dynamodb-tables-resource-based-policy/tests/test.sh
+++ b/tasks/databases-and-storage/dynamodb-tables-resource-based-policy/tests/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/tasks/databases-and-storage/dynamodb-tables-resource-based-policy/tests/test.sh
+++ b/tasks/databases-and-storage/dynamodb-tables-resource-based-policy/tests/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'

--- a/tasks/databases-and-storage/estimate-ec-running-instance-costs/tests/test.sh
+++ b/tasks/databases-and-storage/estimate-ec-running-instance-costs/tests/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/tasks/databases-and-storage/estimate-ec-running-instance-costs/tests/test.sh
+++ b/tasks/databases-and-storage/estimate-ec-running-instance-costs/tests/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'

--- a/tasks/databases-and-storage/get-s-bucket-ownership-controls/tests/test.sh
+++ b/tasks/databases-and-storage/get-s-bucket-ownership-controls/tests/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/tasks/databases-and-storage/get-s-bucket-ownership-controls/tests/test.sh
+++ b/tasks/databases-and-storage/get-s-bucket-ownership-controls/tests/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'

--- a/tasks/databases-and-storage/glue-database-tables-schema-details/tests/test.sh
+++ b/tasks/databases-and-storage/glue-database-tables-schema-details/tests/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/tasks/databases-and-storage/glue-database-tables-schema-details/tests/test.sh
+++ b/tasks/databases-and-storage/glue-database-tables-schema-details/tests/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'

--- a/tasks/databases-and-storage/investigate-athena-table-creation-origin/tests/test.sh
+++ b/tasks/databases-and-storage/investigate-athena-table-creation-origin/tests/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/tasks/databases-and-storage/investigate-athena-table-creation-origin/tests/test.sh
+++ b/tasks/databases-and-storage/investigate-athena-table-creation-origin/tests/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'

--- a/tasks/databases-and-storage/list-buckets-with-lifecycle-policy/tests/test.sh
+++ b/tasks/databases-and-storage/list-buckets-with-lifecycle-policy/tests/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/tasks/databases-and-storage/list-buckets-with-lifecycle-policy/tests/test.sh
+++ b/tasks/databases-and-storage/list-buckets-with-lifecycle-policy/tests/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'

--- a/tasks/databases-and-storage/list-dynamodb-kinesis-streams-all-regions/tests/test.sh
+++ b/tasks/databases-and-storage/list-dynamodb-kinesis-streams-all-regions/tests/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/tasks/databases-and-storage/list-dynamodb-kinesis-streams-all-regions/tests/test.sh
+++ b/tasks/databases-and-storage/list-dynamodb-kinesis-streams-all-regions/tests/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'

--- a/tasks/databases-and-storage/list-dynamodb-tables-all-regions/tests/test.sh
+++ b/tasks/databases-and-storage/list-dynamodb-tables-all-regions/tests/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/tasks/databases-and-storage/list-dynamodb-tables-all-regions/tests/test.sh
+++ b/tasks/databases-and-storage/list-dynamodb-tables-all-regions/tests/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'

--- a/tasks/databases-and-storage/list-s-bucket-subdirectories/tests/test.sh
+++ b/tasks/databases-and-storage/list-s-bucket-subdirectories/tests/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/tasks/databases-and-storage/list-s-bucket-subdirectories/tests/test.sh
+++ b/tasks/databases-and-storage/list-s-bucket-subdirectories/tests/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'

--- a/tasks/databases-and-storage/list-waf-webacl-findings/tests/test.sh
+++ b/tasks/databases-and-storage/list-waf-webacl-findings/tests/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/tasks/databases-and-storage/list-waf-webacl-findings/tests/test.sh
+++ b/tasks/databases-and-storage/list-waf-webacl-findings/tests/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'

--- a/tasks/databases-and-storage/query-dynamodb-filtered-records-count/tests/test.sh
+++ b/tasks/databases-and-storage/query-dynamodb-filtered-records-count/tests/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/tasks/databases-and-storage/query-dynamodb-filtered-records-count/tests/test.sh
+++ b/tasks/databases-and-storage/query-dynamodb-filtered-records-count/tests/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'

--- a/tasks/databases-and-storage/report-unencrypted-s-buckets/tests/test.sh
+++ b/tasks/databases-and-storage/report-unencrypted-s-buckets/tests/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/tasks/databases-and-storage/report-unencrypted-s-buckets/tests/test.sh
+++ b/tasks/databases-and-storage/report-unencrypted-s-buckets/tests/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'

--- a/tasks/databases-and-storage/retrieve-s-csv-object-contents/tests/test.sh
+++ b/tasks/databases-and-storage/retrieve-s-csv-object-contents/tests/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/tasks/databases-and-storage/retrieve-s-csv-object-contents/tests/test.sh
+++ b/tasks/databases-and-storage/retrieve-s-csv-object-contents/tests/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'

--- a/tasks/databases-and-storage/retrieve-s-text-file-contents/tests/test.sh
+++ b/tasks/databases-and-storage/retrieve-s-text-file-contents/tests/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/tasks/databases-and-storage/retrieve-s-text-file-contents/tests/test.sh
+++ b/tasks/databases-and-storage/retrieve-s-text-file-contents/tests/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'

--- a/tasks/databases-and-storage/s-download-csv-identify-columns/tests/test.sh
+++ b/tasks/databases-and-storage/s-download-csv-identify-columns/tests/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/tasks/databases-and-storage/s-download-csv-identify-columns/tests/test.sh
+++ b/tasks/databases-and-storage/s-download-csv-identify-columns/tests/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'

--- a/tasks/databases-and-storage/s-object-versions-and-metadata/tests/test.sh
+++ b/tasks/databases-and-storage/s-object-versions-and-metadata/tests/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/tasks/databases-and-storage/s-object-versions-and-metadata/tests/test.sh
+++ b/tasks/databases-and-storage/s-object-versions-and-metadata/tests/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'

--- a/tasks/databases-and-storage/scan-dynamodb-table-by-status/tests/test.sh
+++ b/tasks/databases-and-storage/scan-dynamodb-table-by-status/tests/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/tasks/databases-and-storage/scan-dynamodb-table-by-status/tests/test.sh
+++ b/tasks/databases-and-storage/scan-dynamodb-table-by-status/tests/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'

--- a/tasks/ec2-multiregion/describe-cloudformation-stack-resources/tests/test.sh
+++ b/tasks/ec2-multiregion/describe-cloudformation-stack-resources/tests/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/tasks/ec2-multiregion/describe-cloudformation-stack-resources/tests/test.sh
+++ b/tasks/ec2-multiregion/describe-cloudformation-stack-resources/tests/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'

--- a/tasks/ec2-multiregion/describe-ec-instances-cross-region-connectivity/tests/test.sh
+++ b/tasks/ec2-multiregion/describe-ec-instances-cross-region-connectivity/tests/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/tasks/ec2-multiregion/describe-ec-instances-cross-region-connectivity/tests/test.sh
+++ b/tasks/ec2-multiregion/describe-ec-instances-cross-region-connectivity/tests/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'

--- a/tasks/ec2-multiregion/ec-instances-without-default-vpc/tests/test.sh
+++ b/tasks/ec2-multiregion/ec-instances-without-default-vpc/tests/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/tasks/ec2-multiregion/ec-instances-without-default-vpc/tests/test.sh
+++ b/tasks/ec2-multiregion/ec-instances-without-default-vpc/tests/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'

--- a/tasks/ec2-multiregion/find-ec-instances-in-public-subnets/tests/test.sh
+++ b/tasks/ec2-multiregion/find-ec-instances-in-public-subnets/tests/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/tasks/ec2-multiregion/find-ec-instances-in-public-subnets/tests/test.sh
+++ b/tasks/ec2-multiregion/find-ec-instances-in-public-subnets/tests/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'

--- a/tasks/ec2-multiregion/list-ec-instances-all-regions-1/tests/test.sh
+++ b/tasks/ec2-multiregion/list-ec-instances-all-regions-1/tests/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/tasks/ec2-multiregion/list-ec-instances-all-regions-1/tests/test.sh
+++ b/tasks/ec2-multiregion/list-ec-instances-all-regions-1/tests/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'

--- a/tasks/ec2-multiregion/list-ec-instances-all-regions/tests/test.sh
+++ b/tasks/ec2-multiregion/list-ec-instances-all-regions/tests/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/tasks/ec2-multiregion/list-ec-instances-all-regions/tests/test.sh
+++ b/tasks/ec2-multiregion/list-ec-instances-all-regions/tests/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'

--- a/tasks/ec2-multiregion/list-ec-instances-by-vpc-across-regions/tests/test.sh
+++ b/tasks/ec2-multiregion/list-ec-instances-by-vpc-across-regions/tests/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/tasks/ec2-multiregion/list-ec-instances-by-vpc-across-regions/tests/test.sh
+++ b/tasks/ec2-multiregion/list-ec-instances-by-vpc-across-regions/tests/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'

--- a/tasks/ec2-multiregion/list-ec-private-ips-all-regions/tests/test.sh
+++ b/tasks/ec2-multiregion/list-ec-private-ips-all-regions/tests/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/tasks/ec2-multiregion/list-ec-private-ips-all-regions/tests/test.sh
+++ b/tasks/ec2-multiregion/list-ec-private-ips-all-regions/tests/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'

--- a/tasks/ec2-multiregion/list-unused-security-groups-all-regions/tests/test.sh
+++ b/tasks/ec2-multiregion/list-unused-security-groups-all-regions/tests/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/tasks/ec2-multiregion/list-unused-security-groups-all-regions/tests/test.sh
+++ b/tasks/ec2-multiregion/list-unused-security-groups-all-regions/tests/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'

--- a/tasks/reference-architectures/analyze-stepfunctions-job-poller-loop/tests/test.sh
+++ b/tasks/reference-architectures/analyze-stepfunctions-job-poller-loop/tests/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/tasks/reference-architectures/analyze-stepfunctions-job-poller-loop/tests/test.sh
+++ b/tasks/reference-architectures/analyze-stepfunctions-job-poller-loop/tests/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'

--- a/tasks/reference-architectures/audit-cognito-account-recovery/tests/test.sh
+++ b/tasks/reference-architectures/audit-cognito-account-recovery/tests/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/tasks/reference-architectures/audit-cognito-account-recovery/tests/test.sh
+++ b/tasks/reference-architectures/audit-cognito-account-recovery/tests/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'

--- a/tasks/reference-architectures/diagnose-batch-job-no-logs/tests/test.sh
+++ b/tasks/reference-architectures/diagnose-batch-job-no-logs/tests/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/tasks/reference-architectures/diagnose-batch-job-no-logs/tests/test.sh
+++ b/tasks/reference-architectures/diagnose-batch-job-no-logs/tests/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'

--- a/tasks/reference-architectures/diagnose-glue-pipeline-not-running/tests/test.sh
+++ b/tasks/reference-architectures/diagnose-glue-pipeline-not-running/tests/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/tasks/reference-architectures/diagnose-glue-pipeline-not-running/tests/test.sh
+++ b/tasks/reference-architectures/diagnose-glue-pipeline-not-running/tests/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'

--- a/tasks/reference-architectures/diagnose-rabbitmq-consumer-failure/tests/test.sh
+++ b/tasks/reference-architectures/diagnose-rabbitmq-consumer-failure/tests/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/tasks/reference-architectures/diagnose-rabbitmq-consumer-failure/tests/test.sh
+++ b/tasks/reference-architectures/diagnose-rabbitmq-consumer-failure/tests/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'

--- a/tasks/reference-architectures/diagnose-rekognition-reupload-stale/tests/test.sh
+++ b/tasks/reference-architectures/diagnose-rekognition-reupload-stale/tests/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/tasks/reference-architectures/diagnose-rekognition-reupload-stale/tests/test.sh
+++ b/tasks/reference-architectures/diagnose-rekognition-reupload-stale/tests/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'

--- a/tasks/reference-architectures/diagnose-s3-event-notification-break/tests/test.sh
+++ b/tasks/reference-architectures/diagnose-s3-event-notification-break/tests/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/tasks/reference-architectures/diagnose-s3-event-notification-break/tests/test.sh
+++ b/tasks/reference-architectures/diagnose-s3-event-notification-break/tests/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'

--- a/tasks/reference-architectures/diagnose-sftp-alarm-not-firing/tests/test.sh
+++ b/tasks/reference-architectures/diagnose-sftp-alarm-not-firing/tests/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/tasks/reference-architectures/diagnose-sftp-alarm-not-firing/tests/test.sh
+++ b/tasks/reference-architectures/diagnose-sftp-alarm-not-firing/tests/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'

--- a/tasks/reference-architectures/review-aurora-production-readiness/tests/test.sh
+++ b/tasks/reference-architectures/review-aurora-production-readiness/tests/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/tasks/reference-architectures/review-aurora-production-readiness/tests/test.sh
+++ b/tasks/reference-architectures/review-aurora-production-readiness/tests/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'

--- a/tasks/reference-architectures/review-backup-plan-cross-region/tests/test.sh
+++ b/tasks/reference-architectures/review-backup-plan-cross-region/tests/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/tasks/reference-architectures/review-backup-plan-cross-region/tests/test.sh
+++ b/tasks/reference-architectures/review-backup-plan-cross-region/tests/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'

--- a/tasks/reference-architectures/trace-ec2-ssh-access-path/tests/test.sh
+++ b/tasks/reference-architectures/trace-ec2-ssh-access-path/tests/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/tasks/reference-architectures/trace-ec2-ssh-access-path/tests/test.sh
+++ b/tasks/reference-architectures/trace-ec2-ssh-access-path/tests/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'

--- a/tasks/serverless-apps/check-lambda-layers-s-code/tests/test.sh
+++ b/tasks/serverless-apps/check-lambda-layers-s-code/tests/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/tasks/serverless-apps/check-lambda-layers-s-code/tests/test.sh
+++ b/tasks/serverless-apps/check-lambda-layers-s-code/tests/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'

--- a/tasks/serverless-apps/check-s-buckets-public-access/tests/test.sh
+++ b/tasks/serverless-apps/check-s-buckets-public-access/tests/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/tasks/serverless-apps/check-s-buckets-public-access/tests/test.sh
+++ b/tasks/serverless-apps/check-s-buckets-public-access/tests/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'

--- a/tasks/serverless-apps/check-s-lifecycle-tag-filter-rules/tests/test.sh
+++ b/tasks/serverless-apps/check-s-lifecycle-tag-filter-rules/tests/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/tasks/serverless-apps/check-s-lifecycle-tag-filter-rules/tests/test.sh
+++ b/tasks/serverless-apps/check-s-lifecycle-tag-filter-rules/tests/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'

--- a/tasks/serverless-apps/ecs-services-custom-configurations-check/tests/test.sh
+++ b/tasks/serverless-apps/ecs-services-custom-configurations-check/tests/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/tasks/serverless-apps/ecs-services-custom-configurations-check/tests/test.sh
+++ b/tasks/serverless-apps/ecs-services-custom-configurations-check/tests/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'

--- a/tasks/serverless-apps/ecs-services-ecr-access-check/tests/test.sh
+++ b/tasks/serverless-apps/ecs-services-ecr-access-check/tests/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/tasks/serverless-apps/ecs-services-ecr-access-check/tests/test.sh
+++ b/tasks/serverless-apps/ecs-services-ecr-access-check/tests/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'

--- a/tasks/serverless-apps/find-lambda-functions-tagged-blueprint/tests/test.sh
+++ b/tasks/serverless-apps/find-lambda-functions-tagged-blueprint/tests/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/tasks/serverless-apps/find-lambda-functions-tagged-blueprint/tests/test.sh
+++ b/tasks/serverless-apps/find-lambda-functions-tagged-blueprint/tests/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'

--- a/tasks/serverless-apps/find-metric-streams-excluding-namespace/tests/test.sh
+++ b/tasks/serverless-apps/find-metric-streams-excluding-namespace/tests/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/tasks/serverless-apps/find-metric-streams-excluding-namespace/tests/test.sh
+++ b/tasks/serverless-apps/find-metric-streams-excluding-namespace/tests/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'

--- a/tasks/serverless-apps/find-sns-triggered-lambda-functions/tests/test.sh
+++ b/tasks/serverless-apps/find-sns-triggered-lambda-functions/tests/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/tasks/serverless-apps/find-sns-triggered-lambda-functions/tests/test.sh
+++ b/tasks/serverless-apps/find-sns-triggered-lambda-functions/tests/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'

--- a/tasks/serverless-apps/list-s-buckets-website-hosting/tests/test.sh
+++ b/tasks/serverless-apps/list-s-buckets-website-hosting/tests/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/tasks/serverless-apps/list-s-buckets-website-hosting/tests/test.sh
+++ b/tasks/serverless-apps/list-s-buckets-website-hosting/tests/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'

--- a/tasks/serverless-apps/list-s-buckets-with-metrics-tag-filters/tests/test.sh
+++ b/tasks/serverless-apps/list-s-buckets-with-metrics-tag-filters/tests/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/tasks/serverless-apps/list-s-buckets-with-metrics-tag-filters/tests/test.sh
+++ b/tasks/serverless-apps/list-s-buckets-with-metrics-tag-filters/tests/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'

--- a/tasks/serverless-apps/list-s-cross-account-analytics-exports/tests/test.sh
+++ b/tasks/serverless-apps/list-s-cross-account-analytics-exports/tests/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/tasks/serverless-apps/list-s-cross-account-analytics-exports/tests/test.sh
+++ b/tasks/serverless-apps/list-s-cross-account-analytics-exports/tests/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'

--- a/tasks/serverless-apps/list-s-inventory-configs-with-prefix/tests/test.sh
+++ b/tasks/serverless-apps/list-s-inventory-configs-with-prefix/tests/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/tasks/serverless-apps/list-s-inventory-configs-with-prefix/tests/test.sh
+++ b/tasks/serverless-apps/list-s-inventory-configs-with-prefix/tests/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'

--- a/tasks/serverless-apps/s-bucket-metrics-tag-filter-check/tests/test.sh
+++ b/tasks/serverless-apps/s-bucket-metrics-tag-filter-check/tests/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/tasks/serverless-apps/s-bucket-metrics-tag-filter-check/tests/test.sh
+++ b/tasks/serverless-apps/s-bucket-metrics-tag-filter-check/tests/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'

--- a/tasks/troubleshooting-multiservice/asg-instance-health-check-failure/tests/test.sh
+++ b/tasks/troubleshooting-multiservice/asg-instance-health-check-failure/tests/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/tasks/troubleshooting-multiservice/asg-instance-health-check-failure/tests/test.sh
+++ b/tasks/troubleshooting-multiservice/asg-instance-health-check-failure/tests/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'

--- a/tasks/troubleshooting-multiservice/asg-secondary-network-interface-attach-failure/tests/test.sh
+++ b/tasks/troubleshooting-multiservice/asg-secondary-network-interface-attach-failure/tests/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/tasks/troubleshooting-multiservice/asg-secondary-network-interface-attach-failure/tests/test.sh
+++ b/tasks/troubleshooting-multiservice/asg-secondary-network-interface-attach-failure/tests/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'

--- a/tasks/troubleshooting-multiservice/check-vpc-flow-log-destinations/tests/test.sh
+++ b/tasks/troubleshooting-multiservice/check-vpc-flow-log-destinations/tests/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/tasks/troubleshooting-multiservice/check-vpc-flow-log-destinations/tests/test.sh
+++ b/tasks/troubleshooting-multiservice/check-vpc-flow-log-destinations/tests/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'

--- a/tasks/troubleshooting-multiservice/diagnose-asg-instance-issues/tests/test.sh
+++ b/tasks/troubleshooting-multiservice/diagnose-asg-instance-issues/tests/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/tasks/troubleshooting-multiservice/diagnose-asg-instance-issues/tests/test.sh
+++ b/tasks/troubleshooting-multiservice/diagnose-asg-instance-issues/tests/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'

--- a/tasks/troubleshooting-multiservice/diagnose-auto-scaling-group-launch-failure/tests/test.sh
+++ b/tasks/troubleshooting-multiservice/diagnose-auto-scaling-group-launch-failure/tests/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/tasks/troubleshooting-multiservice/diagnose-auto-scaling-group-launch-failure/tests/test.sh
+++ b/tasks/troubleshooting-multiservice/diagnose-auto-scaling-group-launch-failure/tests/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'

--- a/tasks/troubleshooting-multiservice/diagnose-ecs-cluster-no-traffic/tests/test.sh
+++ b/tasks/troubleshooting-multiservice/diagnose-ecs-cluster-no-traffic/tests/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/tasks/troubleshooting-multiservice/diagnose-ecs-cluster-no-traffic/tests/test.sh
+++ b/tasks/troubleshooting-multiservice/diagnose-ecs-cluster-no-traffic/tests/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'

--- a/tasks/troubleshooting-multiservice/diagnose-ecs-service-no-running-tasks-1/tests/test.sh
+++ b/tasks/troubleshooting-multiservice/diagnose-ecs-service-no-running-tasks-1/tests/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/tasks/troubleshooting-multiservice/diagnose-ecs-service-no-running-tasks-1/tests/test.sh
+++ b/tasks/troubleshooting-multiservice/diagnose-ecs-service-no-running-tasks-1/tests/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'

--- a/tasks/troubleshooting-multiservice/diagnose-emr-cluster-performance-issues/tests/test.sh
+++ b/tasks/troubleshooting-multiservice/diagnose-emr-cluster-performance-issues/tests/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/tasks/troubleshooting-multiservice/diagnose-emr-cluster-performance-issues/tests/test.sh
+++ b/tasks/troubleshooting-multiservice/diagnose-emr-cluster-performance-issues/tests/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'

--- a/tasks/troubleshooting-multiservice/diagnose-redshift-cluster-health-issues/tests/test.sh
+++ b/tasks/troubleshooting-multiservice/diagnose-redshift-cluster-health-issues/tests/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/tasks/troubleshooting-multiservice/diagnose-redshift-cluster-health-issues/tests/test.sh
+++ b/tasks/troubleshooting-multiservice/diagnose-redshift-cluster-health-issues/tests/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'

--- a/tasks/troubleshooting-multiservice/diagnose-step-functions-failing-executions/tests/test.sh
+++ b/tasks/troubleshooting-multiservice/diagnose-step-functions-failing-executions/tests/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/tasks/troubleshooting-multiservice/diagnose-step-functions-failing-executions/tests/test.sh
+++ b/tasks/troubleshooting-multiservice/diagnose-step-functions-failing-executions/tests/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'

--- a/tasks/troubleshooting-multiservice/ec-instance-security-vulnerability-scan/tests/test.sh
+++ b/tasks/troubleshooting-multiservice/ec-instance-security-vulnerability-scan/tests/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/tasks/troubleshooting-multiservice/ec-instance-security-vulnerability-scan/tests/test.sh
+++ b/tasks/troubleshooting-multiservice/ec-instance-security-vulnerability-scan/tests/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'

--- a/tasks/troubleshooting-multiservice/ec-secrets-manager-exit-code-error/tests/test.sh
+++ b/tasks/troubleshooting-multiservice/ec-secrets-manager-exit-code-error/tests/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/tasks/troubleshooting-multiservice/ec-secrets-manager-exit-code-error/tests/test.sh
+++ b/tasks/troubleshooting-multiservice/ec-secrets-manager-exit-code-error/tests/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'

--- a/tasks/troubleshooting-multiservice/ecs-elasticache-transit-gateway-connectivity/tests/test.sh
+++ b/tasks/troubleshooting-multiservice/ecs-elasticache-transit-gateway-connectivity/tests/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/tasks/troubleshooting-multiservice/ecs-elasticache-transit-gateway-connectivity/tests/test.sh
+++ b/tasks/troubleshooting-multiservice/ecs-elasticache-transit-gateway-connectivity/tests/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'

--- a/tasks/troubleshooting-multiservice/ecs-service-deployment-failure-diagnosis/tests/test.sh
+++ b/tasks/troubleshooting-multiservice/ecs-service-deployment-failure-diagnosis/tests/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/tasks/troubleshooting-multiservice/ecs-service-deployment-failure-diagnosis/tests/test.sh
+++ b/tasks/troubleshooting-multiservice/ecs-service-deployment-failure-diagnosis/tests/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'

--- a/tasks/troubleshooting-multiservice/eventbridge-ecs-task-trigger-debugging/tests/test.sh
+++ b/tasks/troubleshooting-multiservice/eventbridge-ecs-task-trigger-debugging/tests/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/tasks/troubleshooting-multiservice/eventbridge-ecs-task-trigger-debugging/tests/test.sh
+++ b/tasks/troubleshooting-multiservice/eventbridge-ecs-task-trigger-debugging/tests/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'

--- a/tasks/troubleshooting-multiservice/fix-cloudformation-update-failed-stack/tests/test.sh
+++ b/tasks/troubleshooting-multiservice/fix-cloudformation-update-failed-stack/tests/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/tasks/troubleshooting-multiservice/fix-cloudformation-update-failed-stack/tests/test.sh
+++ b/tasks/troubleshooting-multiservice/fix-cloudformation-update-failed-stack/tests/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'

--- a/tasks/troubleshooting-multiservice/glue-job-wrong-deployment-region/tests/test.sh
+++ b/tasks/troubleshooting-multiservice/glue-job-wrong-deployment-region/tests/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/tasks/troubleshooting-multiservice/glue-job-wrong-deployment-region/tests/test.sh
+++ b/tasks/troubleshooting-multiservice/glue-job-wrong-deployment-region/tests/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'

--- a/tasks/troubleshooting-multiservice/lambda-appconfig-stale-value-troubleshoot/tests/test.sh
+++ b/tasks/troubleshooting-multiservice/lambda-appconfig-stale-value-troubleshoot/tests/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/tasks/troubleshooting-multiservice/lambda-appconfig-stale-value-troubleshoot/tests/test.sh
+++ b/tasks/troubleshooting-multiservice/lambda-appconfig-stale-value-troubleshoot/tests/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'

--- a/tasks/troubleshooting-multiservice/troubleshoot-asg-ssh-connectivity/tests/test.sh
+++ b/tasks/troubleshooting-multiservice/troubleshoot-asg-ssh-connectivity/tests/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/tasks/troubleshooting-multiservice/troubleshoot-asg-ssh-connectivity/tests/test.sh
+++ b/tasks/troubleshooting-multiservice/troubleshoot-asg-ssh-connectivity/tests/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'

--- a/tasks/troubleshooting-multiservice/troubleshoot-glue-job-table-read-failure/tests/test.sh
+++ b/tasks/troubleshooting-multiservice/troubleshoot-glue-job-table-read-failure/tests/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/tasks/troubleshooting-multiservice/troubleshoot-glue-job-table-read-failure/tests/test.sh
+++ b/tasks/troubleshooting-multiservice/troubleshoot-glue-job-table-read-failure/tests/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'

--- a/tasks/troubleshooting-multiservice/verify-ec-traffic-routes-through-network-firewall/tests/test.sh
+++ b/tasks/troubleshooting-multiservice/verify-ec-traffic-routes-through-network-firewall/tests/test.sh
@@ -5,7 +5,42 @@
 # resolve_placeholders.py for details), then invokes rewardkit. boto3 is
 # pulled in for transitive botocore (LiteLLM-Bedrock needs it; harbor-rewardkit
 # doesn't declare it itself).
-set -ex
+set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+
+# rewardkit only retries its own judge call on a malformed JSON response ---
+# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
+# fails the whole invocation, and with it the whole trial, even though the
+# agent's own work was fine. Retry the invocation, but only when the
+# failure looks transient: a real rubric/config bug should fail fast rather
+# than burn the verifier's timeout budget on retries that can't succeed.
+#
+# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
+# per-call timeout while several tasks set [verifier].timeout_sec as low as
+# 240s for the *entire* verify step, so a large retry budget can itself
+# cause a timeout. Tasks with slower judges can raise these via
+# [verifier.env] in task.toml.
+REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
+REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
+REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'
+
+attempt=1
+while true; do
+    # $? right after `fi` is the if-statement's own exit status (0 when the
+    # condition is false and there's no else), not the condition's exit
+    # status -- capture it inside `else` instead, before anything else runs.
+    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+        break
+    else
+        status=$?
+    fi
+    if [[ "$attempt" -ge "$REWARDKIT_RETRY_MAX_ATTEMPTS" ]] \
+        || ! grep -qiE "$REWARDKIT_RETRY_TRANSIENT_PATTERN" <<< "$output"; then
+        exit "$status"
+    fi
+    delay=$((REWARDKIT_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1))))
+    echo "rewardkit: transient Bedrock/LiteLLM error on attempt $attempt/$REWARDKIT_RETRY_MAX_ATTEMPTS; retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/tasks/troubleshooting-multiservice/verify-ec-traffic-routes-through-network-firewall/tests/test.sh
+++ b/tasks/troubleshooting-multiservice/verify-ec-traffic-routes-through-network-firewall/tests/test.sh
@@ -9,18 +9,11 @@ set -exo pipefail
 
 uv run --no-project /tests/resolve_placeholders.py
 
-# rewardkit only retries its own judge call on a malformed JSON response ---
-# a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset)
-# fails the whole invocation, and with it the whole trial, even though the
-# agent's own work was fine. Retry the invocation, but only when the
-# failure looks transient: a real rubric/config bug should fail fast rather
-# than burn the verifier's timeout budget on retries that can't succeed.
-#
-# Keep the retry budget modest: rewardkit's LLMJudge defaults to a 300s
-# per-call timeout while several tasks set [verifier].timeout_sec as low as
-# 240s for the *entire* verify step, so a large retry budget can itself
-# cause a timeout. Tasks with slower judges can raise these via
-# [verifier.env] in task.toml.
+# rewardkit retries malformed judge JSON internally but not transient
+# Bedrock/LiteLLM errors. This adds that retry, matching only known transient
+# signatures so a genuine rubric/config error still fails fast. The budget is
+# kept modest: LLMJudge's 300s per-call timeout can exceed a task's
+# [verifier].timeout_sec (as low as 240s); override via [verifier.env] if needed.
 REWARDKIT_RETRY_MAX_ATTEMPTS="${REWARDKIT_RETRY_MAX_ATTEMPTS:-3}"
 REWARDKIT_RETRY_BASE_DELAY_SEC="${REWARDKIT_RETRY_BASE_DELAY_SEC:-5}"
 REWARDKIT_RETRY_TRANSIENT_PATTERN='throttl|rate.?limit|too many requests|service.?unavailable|internal.?server|bad.?gateway|connection reset|connection aborted|read timeout|connect.?timeout|remoteprotocolerror|apiconnectionerror|modeltimeoutexception|modelnotreadyexception|http status code: (429|500|502|503|504)'


### PR DESCRIPTION
rewardkit only retries its own judge call on a malformed JSON response; a transient Bedrock/LiteLLM error (throttling, 5xx, connection reset) previously failed the whole verifier invocation, failing the trial even though the agent's own work was fine. tests/test.sh now retries the rewardkit invocation with exponential backoff when the failure output matches a transient-error signature, and fails fast otherwise so real rubric/config bugs surface immediately.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.