### PR TITLE
fix(scenario): add explicit tableType to Glue table definition

### DIFF
--- a/scenarios/databases-and-storage/scenario/cdk_app/stacks/athena/athena_ton59ib3f.ts
+++ b/scenarios/databases-and-storage/scenario/cdk_app/stacks/athena/athena_ton59ib3f.ts
@@ -54,6 +54,7 @@ export class athena_ton59ib3f extends cdk.Stack {
             databaseName: andesDatabase.ref,
             tableInput: {
                 name: 'andes_3_0_data',
+                tableType: 'EXTERNAL_TABLE',
                 storageDescriptor: {
                     columns: [
                         { name: 'id', type: 'bigint' },

--- a/tasks/databases-and-storage/glue-database-tables-schema-details/solution/solve.sh
+++ b/tasks/databases-and-storage/glue-database-tables-schema-details/solution/solve.sh
@@ -7,12 +7,14 @@ mkdir -p "$(dirname "$OUT")"
 
 TABLE_NAMES=$(aws glue get-tables --database-name "$DATABASE_NAME" --region "$REGION" \
     --query "TableList[].Name" --output text)
-TABLE_COUNT=$(printf '%s\n' $TABLE_NAMES | grep -c .)
+# Split table names into array for safe iteration
+read -ra TABLE_ARRAY <<< "$TABLE_NAMES"
+TABLE_COUNT=${#TABLE_ARRAY[@]}
 
 {
     echo "The database ${DATABASE_NAME} contains ${TABLE_COUNT} table(s): ${TABLE_NAMES}."
     echo ""
-    for NAME in $TABLE_NAMES; do
+    for NAME in "${TABLE_ARRAY[@]}"; do
         TYPE=$(aws glue get-table --database-name "$DATABASE_NAME" --name "$NAME" --region "$REGION" \
             --query "Table.TableType" --output text)
         LOCATION=$(aws glue get-table --database-name "$DATABASE_NAME" --name "$NAME" --region "$REGION" \
@@ -21,9 +23,6 @@ TABLE_COUNT=$(printf '%s\n' $TABLE_NAMES | grep -c .)
             --query "Table.StorageDescriptor.Columns[].[Name,Type]" --output text)
         COL_COUNT=$(printf '%s\n' "$COLS" | grep -c .)
         COL_LIST=$(printf '%s\n' "$COLS" | awk '{printf "%s%s (%s)", sep, $1, $2; sep=", "}')
-        if [ "$TYPE" = "None" ] && [ "$LOCATION" != "None" ]; then
-            TYPE="EXTERNAL_TABLE"
-        fi
         echo "Table ${NAME} (TableType: ${TYPE}) has ${COL_COUNT} columns: ${COL_LIST}."
         echo "Its data is stored externally in S3 at ${LOCATION}, so it is an external table."
         echo ""


### PR DESCRIPTION
## Summary

Add `tableType: 'EXTERNAL_TABLE'` to the CDK Glue table definition and remove the workaround heuristic from the solution.

## Problem

The CDK stack (`athena_ton59ib3f.ts`) creates a Glue table without specifying `tableType`. The Glue API then returns `TableType: null` for `get-table`, but the ground truth expects `EXTERNAL_TABLE`. The solution hid this with a fallback: `if TYPE=None and LOCATION != None then TYPE=EXTERNAL_TABLE`.

## Fix

- **`athena_ton59ib3f.ts`**: Add `tableType: 'EXTERNAL_TABLE'` to `tableInput`
- **`solve.sh`**: Remove the fallback heuristic. Convert to proper bash array handling (fixes ShellCheck SC2086).

## Testing

| Check | Result |
|-------|--------|
| CDK typecheck | ✅ Clean |
| ShellCheck | ✅ Clean (0 warnings) |
| `make check` | ✅ Passed |
| Shared tasks/judge sync | ✅ In sync |
| Deploy `update-table` to env | ✅ `TableType=EXTERNAL_TABLE` confirmed |
| Oracle k=3 | ✅ 3/3 (reward 1.0) |
| Real agent (baseline, sonnet-4.5) k=2 | ✅ 2/2 (reward 1.0) |

Environment: `databases-and-storage` (account 434978747524, us-east-1)

## Note

The CDK change requires a stack update (`env setup`) for new deployments. For the existing environment, the table was updated directly via `aws glue update-table`.

