### PR TITLE
fix(rekognition): establish the re-upload state the task describes

### DIFF
--- a/tasks/reference-architectures/diagnose-rekognition-reupload-stale/post_invoke/post_invoke.py
+++ b/tasks/reference-architectures/diagnose-rekognition-reupload-stale/post_invoke/post_invoke.py
@@ -1,20 +1,25 @@
 """Post-invoke for diagnose-rekognition-reupload-stale.
 
-Deletes the alpha.jpg object and its table row so the account returns to the
-empty-bucket, empty-table baseline the setup snapshot captured.
+Deletes the alpha.jpg object, its table row, and the handler's log group so the
+account returns to the empty-bucket, empty-table, no-log-group baseline the setup
+snapshot captured.
 
-Deleting the object re-triggers the notification only for ObjectCreated, so this
-cleanup does not invoke the handler again. Log events from the trial are left in
-place: CloudWatch Logs retention owns them and the next pre-invoke scopes its
-search by timestamp.
+The log group is not declared by the stack: Lambda creates it on first
+invocation, which this task's pre-invoke triggers. Removing it here keeps the
+account free of resources the trial introduced. It runs after the verifier has
+already scored, so deleting the evidence the judge read is safe.
 
-Idempotent: an absent object, an absent row, and a torn-down stack are all
-treated as already clean.
+Deleting the object emits ObjectRemoved, which no notification is configured for,
+so this cleanup does not invoke the handler again.
+
+Idempotent: an absent object, row, log group, or torn-down stack are all treated
+as already clean.
 
 Env vars (from ``[post_invoke.env]`` in task.toml):
-    BUCKET_NAME  Bucket to clear.
-    TABLE_NAME   Table to clear.
-    AWS_REGION   Region the stack lives in.
+    BUCKET_NAME    Bucket to clear.
+    TABLE_NAME     Table to clear.
+    FUNCTION_NAME  Handler whose log group is removed.
+    AWS_REGION     Region the stack lives in.
 """
 
 import logging
@@ -35,10 +40,12 @@ GONE_CODES = ("NoSuchBucket", "NoSuchKey", "ResourceNotFoundException")
 def run() -> None:
     bucket = os.environ["BUCKET_NAME"]
     table = os.environ["TABLE_NAME"]
+    function_name = os.environ["FUNCTION_NAME"]
     region = os.environ["AWS_REGION"]
 
     s3 = boto3.client("s3", region_name=region)
     ddb = boto3.client("dynamodb", region_name=region)
+    logs = boto3.client("logs", region_name=region)
 
     try:
         s3.delete_object(Bucket=bucket, Key=OBJECT_KEY)
@@ -55,6 +62,15 @@ def run() -> None:
         if e.response.get("Error", {}).get("Code") not in GONE_CODES:
             raise
         logger.info(f"{table} already absent")
+
+    group = f"/aws/lambda/{function_name}"
+    try:
+        logs.delete_log_group(logGroupName=group)
+        logger.info(f"deleted log group {group}")
+    except ClientError as e:
+        if e.response.get("Error", {}).get("Code") not in GONE_CODES:
+            raise
+        logger.info(f"log group {group} already absent")
 
 
 if __name__ == "__main__":

--- a/tasks/reference-architectures/diagnose-rekognition-reupload-stale/post_invoke/post_invoke.py
+++ b/tasks/reference-architectures/diagnose-rekognition-reupload-stale/post_invoke/post_invoke.py
@@ -1,0 +1,66 @@
+"""Post-invoke for diagnose-rekognition-reupload-stale.
+
+Deletes the alpha.jpg object and its table row so the account returns to the
+empty-bucket, empty-table baseline the setup snapshot captured.
+
+Deleting the object re-triggers the notification only for ObjectCreated, so this
+cleanup does not invoke the handler again. Log events from the trial are left in
+place: CloudWatch Logs retention owns them and the next pre-invoke scopes its
+search by timestamp.
+
+Idempotent: an absent object, an absent row, and a torn-down stack are all
+treated as already clean.
+
+Env vars (from ``[post_invoke.env]`` in task.toml):
+    BUCKET_NAME  Bucket to clear.
+    TABLE_NAME   Table to clear.
+    AWS_REGION   Region the stack lives in.
+"""
+
+import logging
+import os
+import sys
+
+import boto3
+from botocore.exceptions import ClientError
+
+logger = logging.getLogger(__name__)
+
+OBJECT_KEY = "alpha.jpg"
+
+# Errors meaning the resource is already gone, so cleanup has nothing to do.
+GONE_CODES = ("NoSuchBucket", "NoSuchKey", "ResourceNotFoundException")
+
+
+def run() -> None:
+    bucket = os.environ["BUCKET_NAME"]
+    table = os.environ["TABLE_NAME"]
+    region = os.environ["AWS_REGION"]
+
+    s3 = boto3.client("s3", region_name=region)
+    ddb = boto3.client("dynamodb", region_name=region)
+
+    try:
+        s3.delete_object(Bucket=bucket, Key=OBJECT_KEY)
+        logger.info(f"deleted s3://{bucket}/{OBJECT_KEY}")
+    except ClientError as e:
+        if e.response.get("Error", {}).get("Code") not in GONE_CODES:
+            raise
+        logger.info(f"s3://{bucket}/{OBJECT_KEY} already absent")
+
+    try:
+        ddb.delete_item(TableName=table, Key={"image_name": {"S": OBJECT_KEY}})
+        logger.info(f"deleted {table} row for {OBJECT_KEY}")
+    except ClientError as e:
+        if e.response.get("Error", {}).get("Code") not in GONE_CODES:
+            raise
+        logger.info(f"{table} already absent")
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    try:
+        run()
+    except (ClientError, KeyError) as e:
+        print(f"post_invoke failed: {e}", file=sys.stderr)
+        sys.exit(1)

--- a/tasks/reference-architectures/diagnose-rekognition-reupload-stale/post_invoke/post_invoke.sh
+++ b/tasks/reference-architectures/diagnose-rekognition-reupload-stale/post_invoke/post_invoke.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -euo pipefail
+uv run --with boto3 post_invoke.py

--- a/tasks/reference-architectures/diagnose-rekognition-reupload-stale/pre_invoke/pre_invoke.py
+++ b/tasks/reference-architectures/diagnose-rekognition-reupload-stale/pre_invoke/pre_invoke.py
@@ -1,0 +1,158 @@
+"""Pre-invoke for diagnose-rekognition-reupload-stale.
+
+Creates the runtime state the instruction describes: alpha.jpg uploaded once and
+processed into DynamoDB, then re-uploaded with different bytes under the same
+key, leaving the row holding the first upload's labels. The stack ships the
+conditional-putItem bug but deploys an empty bucket and table, so without this
+hook there is no object, no row, and no exception log for the agent to find.
+
+Both uploads are synthesized as valid JPEGs whose colour differs, so Rekognition
+is exercised on genuinely different bytes. The staleness assertion compares the
+row against itself across the second upload rather than against expected label
+text, because Rekognition's labels are not stable over time.
+
+Env vars (from ``[pre_invoke.env]`` in task.toml):
+    BUCKET_NAME    Bucket the handler watches.
+    TABLE_NAME     Table the handler writes.
+    FUNCTION_NAME  Handler, used to scope the log search.
+    AWS_REGION     Region the stack lives in.
+"""
+
+import io
+import json
+import logging
+import os
+import sys
+import time
+
+import boto3
+from botocore.exceptions import ClientError
+
+logger = logging.getLogger(__name__)
+
+RESULT_FILE = "/logs/pre_invoke/placeholder.json"
+
+OBJECT_KEY = "alpha.jpg"
+
+# S3 notifications are asynchronous and at-least-once, so every step polls.
+ROW_TIMEOUT_SEC = 180
+LOG_TIMEOUT_SEC = 180
+POLL_INTERVAL_SEC = 5
+
+CONDITIONAL_FAILURE_MARKER = "ConditionalCheckFailedException"
+
+
+def _jpeg_bytes(rgb: tuple[int, int, int], size: int = 64) -> bytes:
+    """Return a solid-colour JPEG that Rekognition accepts as image input."""
+    from PIL import Image  # installed by pre_invoke.sh
+
+    buf = io.BytesIO()
+    Image.new("RGB", (size, size), rgb).save(buf, format="JPEG", quality=90)
+    return buf.getvalue()
+
+
+def _get_row(ddb, table: str) -> dict | None:
+    item = ddb.get_item(
+        TableName=table, Key={"image_name": {"S": OBJECT_KEY}}, ConsistentRead=True
+    ).get("Item")
+    return item
+
+
+def _wait_for_row(ddb, table: str) -> dict:
+    """Poll until the handler has written the alpha.jpg row."""
+    deadline = time.monotonic() + ROW_TIMEOUT_SEC
+    while time.monotonic() < deadline:
+        item = _get_row(ddb, table)
+        if item:
+            logger.info(f"row present: {item.get('labels', {}).get('S', '')[:120]}")
+            return item
+        time.sleep(POLL_INTERVAL_SEC)
+    raise TimeoutError(
+        f"{table} had no {OBJECT_KEY} row after {ROW_TIMEOUT_SEC}s; the S3 "
+        f"notification or the handler's first putItem did not complete"
+    )
+
+
+def _wait_for_conditional_failure(logs, function_name: str, since_ms: int) -> None:
+    """Poll the handler's log group for a fresh ConditionalCheckFailedException."""
+    group = f"/aws/lambda/{function_name}"
+    deadline = time.monotonic() + LOG_TIMEOUT_SEC
+    while time.monotonic() < deadline:
+        try:
+            events = logs.filter_log_events(
+                logGroupName=group,
+                startTime=since_ms,
+                filterPattern=f'"{CONDITIONAL_FAILURE_MARKER}"',
+            ).get("events", [])
+        except ClientError as e:
+            if e.response.get("Error", {}).get("Code") == "ResourceNotFoundException":
+                # Group is created on first invocation; keep waiting.
+                events = []
+            else:
+                raise
+        if events:
+            logger.info(
+                f"found {len(events)} fresh {CONDITIONAL_FAILURE_MARKER} event(s)"
+            )
+            return
+        time.sleep(POLL_INTERVAL_SEC)
+    raise TimeoutError(
+        f"no {CONDITIONAL_FAILURE_MARKER} in {group} within {LOG_TIMEOUT_SEC}s of "
+        f"the re-upload; the handler's conditional putItem did not fail as expected"
+    )
+
+
+def run() -> dict[str, str]:
+    bucket = os.environ["BUCKET_NAME"]
+    table = os.environ["TABLE_NAME"]
+    function_name = os.environ["FUNCTION_NAME"]
+    region = os.environ["AWS_REGION"]
+
+    s3 = boto3.client("s3", region_name=region)
+    ddb = boto3.client("dynamodb", region_name=region)
+    logs = boto3.client("logs", region_name=region)
+
+    # Start from a known-clean state so the first upload really is the first.
+    s3.delete_object(Bucket=bucket, Key=OBJECT_KEY)
+    ddb.delete_item(TableName=table, Key={"image_name": {"S": OBJECT_KEY}})
+    logger.info(f"cleared prior {OBJECT_KEY} object and row")
+
+    first = _jpeg_bytes((200, 30, 30))
+    s3.put_object(Bucket=bucket, Key=OBJECT_KEY, Body=first, ContentType="image/jpeg")
+    logger.info(f"uploaded {OBJECT_KEY} ({len(first)} bytes)")
+    row_before = _wait_for_row(ddb, table)
+
+    # Second upload: different bytes, same key. Recorded before the put so the
+    # log search cannot match the first invocation.
+    reupload_start_ms = int(time.time() * 1000)
+    second = _jpeg_bytes((30, 60, 200))
+    if second == first:
+        raise RuntimeError("re-upload bytes are identical to the first upload")
+    s3.put_object(Bucket=bucket, Key=OBJECT_KEY, Body=second, ContentType="image/jpeg")
+    logger.info(f"re-uploaded {OBJECT_KEY} ({len(second)} bytes)")
+
+    _wait_for_conditional_failure(logs, function_name, reupload_start_ms)
+
+    # The row must be byte-identical to the pre-re-upload read: that is the
+    # staleness the task asks the agent to explain.
+    row_after = _get_row(ddb, table)
+    if row_after != row_before:
+        raise RuntimeError(
+            f"{OBJECT_KEY} row changed across the re-upload, so the conditional "
+            f"putItem did not block the write: {row_before} -> {row_after}"
+        )
+    logger.info(f"row unchanged after re-upload; {OBJECT_KEY} is stale as intended")
+
+    return {}
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    try:
+        placeholders = run()
+    except (ClientError, KeyError, RuntimeError, TimeoutError) as e:
+        print(f"pre_invoke failed: {e}", file=sys.stderr)
+        sys.exit(1)
+    os.makedirs(os.path.dirname(RESULT_FILE), exist_ok=True)
+    with open(RESULT_FILE, "w") as f:
+        json.dump(placeholders, f)

--- a/tasks/reference-architectures/diagnose-rekognition-reupload-stale/pre_invoke/pre_invoke.sh
+++ b/tasks/reference-architectures/diagnose-rekognition-reupload-stale/pre_invoke/pre_invoke.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -euo pipefail
+uv run --with boto3 --with pillow pre_invoke.py

--- a/tasks/reference-architectures/diagnose-rekognition-reupload-stale/solution/solve.sh
+++ b/tasks/reference-architectures/diagnose-rekognition-reupload-stale/solution/solve.sh
@@ -32,10 +32,13 @@ CONDITION=$(printf '%s\n' "$HANDLER" | grep -oE "ConditionExpression: *'[^']*'" 
 STORED_LABELS=$(aws dynamodb get-item --table-name "$TABLE_NAME" --region "$REGION" \
     --key '{"image_name":{"S":"alpha.jpg"}}' --consistent-read \
     --query "Item.labels.S" --output text)
+# --no-paginate would still return only the first page's events; let the CLI walk
+# every page and count the matches itself, because the matching event does not
+# necessarily land on page one.
 COND_EVENTS=$(aws logs filter-log-events --region "$REGION" \
     --log-group-name "/aws/lambda/${FUNCTION_NAME}" \
     --filter-pattern '"ConditionalCheckFailedException"' \
-    --query "length(events)" --output text)
+    --query "events[].eventId" --output text | tr '\t' '\n' | grep -c . || true)
 
 DDB=$(aws dynamodb describe-table --table-name "$TABLE_NAME" --region "$REGION" \
     --query "Table.[BillingModeSummary.BillingMode,ProvisionedThroughput.ReadCapacityUnits,ProvisionedThroughput.WriteCapacityUnits]" \

--- a/tasks/reference-architectures/diagnose-rekognition-reupload-stale/solution/solve.sh
+++ b/tasks/reference-architectures/diagnose-rekognition-reupload-stale/solution/solve.sh
@@ -27,6 +27,16 @@ MAX_LABELS=$(printf '%s\n' "$HANDLER" | grep -oE 'MaxLabels: *[0-9]+' | grep -oE
 MIN_CONFIDENCE=$(printf '%s\n' "$HANDLER" | grep -oE 'MinConfidence: *[0-9]+' | grep -oE '[0-9]+')
 CONDITION=$(printf '%s\n' "$HANDLER" | grep -oE "ConditionExpression: *'[^']*'" | grep -oE "attribute_not_exists\([a-z_]+\)")
 
+# Observe the symptom rather than only reading configuration: the stored row and
+# the exception the handler swallowed.
+STORED_LABELS=$(aws dynamodb get-item --table-name "$TABLE_NAME" --region "$REGION" \
+    --key '{"image_name":{"S":"alpha.jpg"}}' --consistent-read \
+    --query "Item.labels.S" --output text)
+COND_EVENTS=$(aws logs filter-log-events --region "$REGION" \
+    --log-group-name "/aws/lambda/${FUNCTION_NAME}" \
+    --filter-pattern '"ConditionalCheckFailedException"' \
+    --query "length(events)" --output text)
+
 DDB=$(aws dynamodb describe-table --table-name "$TABLE_NAME" --region "$REGION" \
     --query "Table.[BillingModeSummary.BillingMode,ProvisionedThroughput.ReadCapacityUnits,ProvisionedThroughput.WriteCapacityUnits]" \
     --output text)
@@ -39,7 +49,7 @@ The S3 event is firing; the team's assumption that the event never fired and ${F
 
 The Lambda runs and calls rekognition.DetectLabels on the new object bytes (MaxLabels ${MAX_LABELS}, MinConfidence ${MIN_CONFIDENCE}), so the Rekognition cost is incurred on every re-upload. The real bug is what the handler does next: its putItem against table ${TABLE_NAME} is issued with ConditionExpression ${CONDITION}, i.e. it requires that the primary key image_name does not already exist. Because the alpha.jpg row was written by the first upload, the second putItem fails with ConditionalCheckFailedException.
 
-The handler wraps that putItem in a try/catch that only logs the error (console.log(err)) and then returns normally, so the invocation exits as a success. That is why Lambda Invocations and Errors look clean, S3 shows successful delivery, and the DynamoDB row for alpha.jpg still contains the old labels. The failure is visible only in CloudWatch Logs for ${FUNCTION_NAME}, where the ConditionalCheckFailedException is printed.
+The handler wraps that putItem in a try/catch that only logs the error (console.log(err)) and then returns normally, so the invocation exits as a success. That is why Lambda Invocations and Errors look clean, S3 shows successful delivery, and the DynamoDB row for alpha.jpg still contains the old labels: reading the row back now returns "${STORED_LABELS}", written by the first upload. The failure is visible only in CloudWatch Logs for ${FUNCTION_NAME}, where ${COND_EVENTS} ConditionalCheckFailedException event(s) are printed.
 
 Diagnosis steps: check the bucket's notification configuration and versioning status (event fires, no versioning); confirm the Lambda's Invocations metric shows the re-upload invocation with no Errors; then read the function's CloudWatch Logs, where the ConditionalCheckFailedException on the conditional putItem appears.
 

--- a/tasks/reference-architectures/diagnose-rekognition-reupload-stale/task.toml
+++ b/tasks/reference-architectures/diagnose-rekognition-reupload-stale/task.toml
@@ -12,7 +12,11 @@ scenario_id = "reference-architectures"
 agent_role_name = "QALocalInvocationApplicationRole"
 
 [concurrency]
-mode = "read-only"
+# The hooks upload an object, write a table row, and cause Lambda to create its
+# log group. Post-invoke reverses all three, but a post-invoke that never runs
+# (a cancelled or crashed trial) would leave them behind, so the trial takes the
+# framework's post-run account reset as its fail-safe.
+mode = "mutating"
 
 [pre_invoke]
 timeout_sec = 600.0
@@ -29,6 +33,7 @@ timeout_sec = 300.0
 [post_invoke.env]
 BUCKET_NAME = "{{reference-architectures-Rekognition-s3trigger-us-east-1-BucketName}}"
 TABLE_NAME = "{{reference-architectures-Rekognition-s3trigger-us-east-1-TableName}}"
+FUNCTION_NAME = "{{reference-architectures-Rekognition-s3trigger-us-east-1-FunctionName}}"
 AWS_REGION = "us-east-1"
 
 # --- Harbor standard --- flexible metadata

--- a/tasks/reference-architectures/diagnose-rekognition-reupload-stale/task.toml
+++ b/tasks/reference-architectures/diagnose-rekognition-reupload-stale/task.toml
@@ -14,6 +14,23 @@ agent_role_name = "QALocalInvocationApplicationRole"
 [concurrency]
 mode = "read-only"
 
+[pre_invoke]
+timeout_sec = 600.0
+
+[pre_invoke.env]
+BUCKET_NAME = "{{reference-architectures-Rekognition-s3trigger-us-east-1-BucketName}}"
+TABLE_NAME = "{{reference-architectures-Rekognition-s3trigger-us-east-1-TableName}}"
+FUNCTION_NAME = "{{reference-architectures-Rekognition-s3trigger-us-east-1-FunctionName}}"
+AWS_REGION = "us-east-1"
+
+[post_invoke]
+timeout_sec = 300.0
+
+[post_invoke.env]
+BUCKET_NAME = "{{reference-architectures-Rekognition-s3trigger-us-east-1-BucketName}}"
+TABLE_NAME = "{{reference-architectures-Rekognition-s3trigger-us-east-1-TableName}}"
+AWS_REGION = "us-east-1"
+
 # --- Harbor standard --- flexible metadata
 [metadata]
 id = "2e9aaa97-8549-4d2d-9132-abc2585a530f"


### PR DESCRIPTION
## Problem

The instruction describes an upload, a re-upload under the same key, and a row left showing the old labels; the ground truth describes a swallowed `ConditionalCheckFailedException`. Deployment created only an empty bucket and table.

Confirmed live on a freshly deployed environment: no `alpha.jpg`, 0 table items, and the handler's log group **did not exist at all** — proof it had never been invoked. The scenario ships the conditional-putItem bug, but nothing created the object, the first row, the second invocation, the stale row, or the exception log.

## Change

- **New `pre_invoke`** clears prior task state, uploads a generated JPEG, waits for the handler to write the row, then re-uploads different bytes under the same key and waits for a `ConditionalCheckFailedException` timestamped after the re-upload began. It then asserts the row is **byte-identical** to the pre-re-upload read — that identity *is* the staleness the task asks about — and fails closed if the row changed, which would mean the bug is gone.
- **New `post_invoke`** deletes the object, the row, and the handler's log group.
- **`solution/solve.sh`** now reads the stored row back and counts the exception events instead of inferring the symptom from configuration and handler source alone.
- **`[concurrency].mode` = `mutating`** (see below).

Images are generated rather than checked in, and staleness is asserted by comparing the row against itself, so the task does not depend on Rekognition returning stable labels over time.

## Why the log group is deleted, and why `mutating`

A live run showed `env verify` reporting one new resource after a trial that passed and whose `post_invoke` completed: the handler's log group. Lambda creates it on first invocation, which `pre_invoke` triggers, and the stack does not declare it. `post_invoke` now removes it — safe because `post_invoke` runs during teardown, **after the verifier has already scored**, so deleting the evidence the judge read affects nothing.

`read-only` was a false declaration under the AGENTS.md rule that a task is read-only only when every lifecycle phase is. `mutating` also adds the framework's post-run account reset as a fail-safe for the case `post_invoke` never runs at all: a cancelled trial skips it by design and would otherwise leave `alpha.jpg`, its row, and the log group behind. Unlike the sibling Batch PR, this task's `post_invoke` does fully restore baseline on its own, so the reset here is pure insurance.

Trade-off worth knowing: `mutating` triggers a full account reset after every trial and serializes this task against others in the scenario.

## Validation

Live, on an approved disposable environment (account `475127833339`, `reference-architectures`):

- Oracle reward **1.0**, reproduced across 4 independent runs.
- `pre_invoke` ran the full chain: cleared state, uploaded, row appeared (`Maroon,Logo`), re-uploaded, 1 fresh `ConditionalCheckFailedException`, row unchanged.
- `post_invoke` deleted all three resources; its idempotent paths were exercised too (already-absent object/row treated as clean).
- **`env verify` passes with no manual reset** after a `mutating` run. Under `read-only` the same run left 1 new resource behind.

One bug this live run caught and fixed (commit 2 of 3): `filter-log-events` paginates, so `--query length(events)` counted only the first page and the CLI emitted one count per page — the shell captured `0` on an account that had the event. Now counts event ids across all pages. Verified live: old query `0`, new query `1`.

Static: 28/28 Jest, `py-lint`, `py-fmt-check`, `shell`, `docker`, `config`, and all sync drift checks pass.

`make check` still fails at `py-typecheck` on `tools/rubric-runner/judge.py:111` (unused `ty: ignore`). Verified by stashing that this fails identically on untouched `main` — pre-existing and unrelated.

Asana: `1217266495896133`