### PR TITLE
fix(tasks): remove duplicate AWS_REGION keys

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -146,7 +146,8 @@ docker: ## hadolint lint
 	fi
 
 # ---- Config (task/scenario metadata) -----------------------------------------
-config: ## Validate task.toml fields + verifier toolchain pinning + lockfile registries
+config: ## Validate task.toml parses + fields + verifier toolchain pinning + lockfile registries
+	bash test/ci_utils/check-task-toml-parses.sh
 	bash test/ci_utils/check-task-fields.sh
 	bash test/ci_utils/check-toolchain-pinning.sh
 	bash test/ci_utils/check-lockfile-registries.sh

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,10 @@ HADOLINT_IMAGE  ?= hadolint/hadolint:latest
 # per-task/per-scenario runtime scripts that execute inside their containers
 # with their own deps). ty typechecks only these paths.
 PY_TYPECHECK_PATHS ?= tools
+# Flat module directories: their .py files import siblings by bare name (e.g.
+# `from lib import ...`). ty resolves modules only from its search path, so each
+# such directory is added to it. Relative to the repo root.
+PY_MODULE_PATHS ?= tools/rubric-runner
 
 # ---- content discovery -------------------------------------------------------
 PRUNE := -path '*/node_modules/*' -o -path '*/cdk.out/*' -o -path '*/dist/*'
@@ -123,7 +127,7 @@ py-lint: ## ruff lint (rule set in pyproject.toml [tool.ruff.lint])
 	$(UVX) ruff check .
 
 py-typecheck: ## ty typecheck of maintained first-party Python
-	$(UVX) ty check $(PY_TYPECHECK_PATHS)
+	$(UVX) ty check $(addprefix --extra-search-path ,$(PY_MODULE_PATHS)) $(PY_TYPECHECK_PATHS)
 
 py-fmt: ## Apply ruff format (mutates files)
 	$(UVX) ruff format .

--- a/tasks/compute-and-data/amplify-deploy-frontend-from-s3/task.toml
+++ b/tasks/compute-and-data/amplify-deploy-frontend-from-s3/task.toml
@@ -32,14 +32,12 @@ timeout_sec = 300.0
 [pre_invoke.env]
 AMPLIFY_DATA_BUCKET = "{{compute-and-data-s3-s5wscsi4m-us-east-1-BucketName}}"
 AWS_REGION = "us-east-1"
-AWS_REGION = "us-east-1"
 
 [post_invoke]
 timeout_sec = 300.0
 
 [post_invoke.env]
 AMPLIFY_DATA_BUCKET = "{{compute-and-data-s3-s5wscsi4m-us-east-1-BucketName}}"
-AWS_REGION = "us-east-1"
 AWS_REGION = "us-east-1"
 
 # --- Harbor standard ---

--- a/tasks/compute-and-data/analyze-b2b-commerce-summary-and-lifecycle/task.toml
+++ b/tasks/compute-and-data/analyze-b2b-commerce-summary-and-lifecycle/task.toml
@@ -32,14 +32,12 @@ timeout_sec = 300.0
 [pre_invoke.env]
 B2B_DATA_BUCKET = "{{compute-and-data-s3-dkj487ewd-us-east-1-BucketName}}"
 AWS_REGION = "us-east-1"
-AWS_REGION = "us-east-1"
 
 [post_invoke]
 timeout_sec = 360.0
 
 [post_invoke.env]
 B2B_DATA_BUCKET = "{{compute-and-data-s3-dkj487ewd-us-east-1-BucketName}}"
-AWS_REGION = "us-east-1"
 AWS_REGION = "us-east-1"
 
 # --- Harbor standard ---

--- a/tasks/compute-and-data/create-athena-tables-from-s3/task.toml
+++ b/tasks/compute-and-data/create-athena-tables-from-s3/task.toml
@@ -29,14 +29,12 @@ timeout_sec = 300.0
 [pre_invoke.env]
 CSV_BUCKET = "{{compute-and-data-athena-k89bh5er2-us-east-1-CsvBucketName}}"
 AWS_REGION = "us-east-1"
-AWS_REGION = "us-east-1"
 
 [post_invoke]
 timeout_sec = 300.0
 
 [post_invoke.env]
 CSV_BUCKET = "{{compute-and-data-athena-k89bh5er2-us-east-1-CsvBucketName}}"
-AWS_REGION = "us-east-1"
 AWS_REGION = "us-east-1"
 
 [agent]

--- a/tasks/compute-and-data/create-eks-cluster/task.toml
+++ b/tasks/compute-and-data/create-eks-cluster/task.toml
@@ -45,7 +45,6 @@ timeout_sec = 2400.0
 timeout_sec = 600.0
 
 [verifier.env]
-AWS_REGION = "us-east-1"
 VPC_ID = "{{compute-and-data-ec2-vlf3847wf-us-east-1-VpcId}}"
 SUBNET_ID_1 = "{{compute-and-data-ec2-vlf3847wf-us-east-1-SubnetId1}}"
 SUBNET_ID_2 = "{{compute-and-data-ec2-vlf3847wf-us-east-1-SubnetId2}}"

--- a/tasks/compute-and-data/expand-elasticsearch-cfn-template/task.toml
+++ b/tasks/compute-and-data/expand-elasticsearch-cfn-template/task.toml
@@ -39,7 +39,6 @@ timeout_sec = 300.0
 [pre_invoke.env]
 BUCKET_NAME = "{{compute-and-data-s3-dz8q7r549-us-east-1-BucketName}}"
 AWS_REGION = "us-east-1"
-AWS_REGION = "us-east-1"
 
 [solution.env]
 BUCKET_NAME = "{{compute-and-data-s3-dz8q7r549-us-east-1-BucketName}}"
@@ -51,7 +50,6 @@ timeout_sec = 360.0
 
 [post_invoke.env]
 BUCKET_NAME = "{{compute-and-data-s3-dz8q7r549-us-east-1-BucketName}}"
-AWS_REGION = "us-east-1"
 AWS_REGION = "us-east-1"
 
 [environment]

--- a/tasks/compute-and-data/invalidate-cloudfront-cache/task.toml
+++ b/tasks/compute-and-data/invalidate-cloudfront-cache/task.toml
@@ -30,14 +30,12 @@ timeout_sec = 300.0
 [pre_invoke.env]
 CF_DATA_BUCKET = "{{compute-and-data-cloudfront-492sidmdo-us-east-1-BucketName}}"
 AWS_REGION = "us-east-1"
-AWS_REGION = "us-east-1"
 
 [post_invoke]
 timeout_sec = 300.0
 
 [post_invoke.env]
 CF_DATA_BUCKET = "{{compute-and-data-cloudfront-492sidmdo-us-east-1-BucketName}}"
-AWS_REGION = "us-east-1"
 AWS_REGION = "us-east-1"
 
 [agent]

--- a/tasks/compute-and-data/manage-buckets-eks-sagemaker/task.toml
+++ b/tasks/compute-and-data/manage-buckets-eks-sagemaker/task.toml
@@ -48,7 +48,6 @@ timeout_sec = 1200.0
 EXPECTED_BUCKETS_CSV = "{{compute-and-data-eks-gztvy25g1-us-east-1-S3BucketNames}}"
 EXPECTED_CLUSTER = "{{compute-and-data-eks-gztvy25g1-us-east-1-EksClusterName}}"
 AWS_REGION = "us-east-1"
-AWS_REGION = "us-east-1"
 
 # --- aws-bench extension --- post_invoke (rollback) runs after verification
 # Note: object-version deletion is irreversible, so post_invoke uninstalls the
@@ -59,7 +58,6 @@ timeout_sec = 1200.0
 [post_invoke.env]
 EXPECTED_CLUSTER = "{{compute-and-data-eks-gztvy25g1-us-east-1-EksClusterName}}"
 EXPECTED_BUCKETS_CSV = "{{compute-and-data-eks-gztvy25g1-us-east-1-S3BucketNames}}"
-AWS_REGION = "us-east-1"
 AWS_REGION = "us-east-1"
 
 [solution.env]

--- a/tasks/compute-and-data/move-s3-contents-and-cleanup/task.toml
+++ b/tasks/compute-and-data/move-s3-contents-and-cleanup/task.toml
@@ -30,7 +30,6 @@ timeout_sec = 300.0
 SOURCE_PATH = "{{compute-and-data-s3-uijodjso5-us-east-1-FolderPath}}"
 DEST_PATH = "{{compute-and-data-s3-uijodjso5-us-east-1-CorrectedFolderPath}}"
 AWS_REGION = "us-east-1"
-AWS_REGION = "us-east-1"
 
 [agent]
 timeout_sec = 1200.0
@@ -53,7 +52,6 @@ timeout_sec = 360.0
 [post_invoke.env]
 SOURCE_PATH = "{{compute-and-data-s3-uijodjso5-us-east-1-FolderPath}}"
 DEST_PATH = "{{compute-and-data-s3-uijodjso5-us-east-1-CorrectedFolderPath}}"
-AWS_REGION = "us-east-1"
 AWS_REGION = "us-east-1"
 
 [environment]

--- a/tasks/compute-and-data/move-s3-contents-within-bucket/task.toml
+++ b/tasks/compute-and-data/move-s3-contents-within-bucket/task.toml
@@ -30,14 +30,12 @@ timeout_sec = 300.0
 [pre_invoke.env]
 MOVE_DATA_BUCKET = "{{compute-and-data-s3-oeimf302d-us-east-1-BucketName}}"
 AWS_REGION = "us-east-1"
-AWS_REGION = "us-east-1"
 
 [post_invoke]
 timeout_sec = 360.0
 
 [post_invoke.env]
 MOVE_DATA_BUCKET = "{{compute-and-data-s3-oeimf302d-us-east-1-BucketName}}"
-AWS_REGION = "us-east-1"
 AWS_REGION = "us-east-1"
 
 [agent]

--- a/tasks/compute-and-data/sync-s3-buckets-with-metadata/task.toml
+++ b/tasks/compute-and-data/sync-s3-buckets-with-metadata/task.toml
@@ -41,7 +41,6 @@ timeout_sec = 300.0
 SYNC_SOURCE_BUCKET = "{{compute-and-data-s3-mnbh73950-us-east-1-SourceBucketName}}"
 DESTINATION_BUCKET = "{{compute-and-data-s3-mnbh73950-us-east-1-DestinationBucketName}}"
 AWS_REGION = "us-east-1"
-AWS_REGION = "us-east-1"
 
 [solution.env]
 SYNC_SOURCE_BUCKET = "{{compute-and-data-s3-mnbh73950-us-east-1-SourceBucketName}}"
@@ -54,7 +53,6 @@ timeout_sec = 360.0
 [post_invoke.env]
 SYNC_SOURCE_BUCKET = "{{compute-and-data-s3-mnbh73950-us-east-1-SourceBucketName}}"
 DESTINATION_BUCKET = "{{compute-and-data-s3-mnbh73950-us-east-1-DestinationBucketName}}"
-AWS_REGION = "us-east-1"
 AWS_REGION = "us-east-1"
 
 [environment]

--- a/test/ci_utils/check-task-toml-parses.sh
+++ b/test/ci_utils/check-task-toml-parses.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+#
+# check-task-toml-parses.sh: parse every task.toml with a real TOML parser and
+# fail on any file the parser rejects.
+#
+# BLOCKING. A task.toml that does not parse cannot be loaded by the framework at
+# run time, so this runs ahead of the field/content checks, which match on text
+# and accept files no parser would.
+#
+# Catches what a text scan cannot: duplicate keys within a table, bad escapes,
+# malformed inline tables/arrays, and any other syntax the spec rejects.
+#
+# Usage:
+#   check-task-toml-parses.sh [task_dir ...]   # default: all tasks/<env>/<task>
+#
+# Output: one "FAIL <path>: <parser message>" line per rejected file plus a
+# trailing count. Exits 1 if any file was rejected, 0 otherwise.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+# tomllib is in the standard library from 3.11. python3 is not a declared
+# prerequisite of this repo but uv is, and uv supplies an interpreter.
+if command -v python3 >/dev/null 2>&1; then
+    PY=(python3)
+else
+    PY=(uv run --no-project --quiet python)
+fi
+
+# Build the file list: a task.toml per argument, or every task's task.toml.
+files=()
+if [ "$#" -gt 0 ]; then
+    for task_dir in "$@"; do
+        [ -f "$task_dir/task.toml" ] && files+=("$task_dir/task.toml")
+    done
+else
+    while IFS= read -r toml; do
+        files+=("$toml")
+    done < <(find "$ROOT_DIR/tasks" -mindepth 3 -maxdepth 3 -name task.toml 2>/dev/null | sort)
+fi
+
+if [ "${#files[@]}" -eq 0 ]; then
+    echo "No task.toml files to check"
+    exit 0
+fi
+
+"${PY[@]}" -c '
+import sys, tomllib
+
+failed = 0
+for path in sys.argv[1:]:
+    try:
+        with open(path, "rb") as fh:
+            tomllib.load(fh)
+    except tomllib.TOMLDecodeError as exc:
+        print(f"FAIL {path}: {exc}")
+        failed += 1
+    except OSError as exc:
+        print(f"FAIL {path}: {exc}")
+        failed += 1
+
+total = len(sys.argv) - 1
+if failed:
+    print(f"\n{failed} of {total} task.toml file(s) are not valid TOML.")
+    sys.exit(1)
+print(f"All {total} task.toml file(s) parse as valid TOML.")
+' "${files[@]}"

--- a/tools/rubric-runner/judge.py
+++ b/tools/rubric-runner/judge.py
@@ -108,7 +108,7 @@ async def judge_one(
 ) -> dict:
     """Run harbor check on one task; persist and return a small status record."""
     # Imported lazily so --help works without harbor installed.
-    from harbor.analyze.checker import run_check  # ty: ignore[unresolved-import]
+    from harbor.analyze.checker import run_check
 
     slug = task_slug(task_dir)
     task_type = detect_task_type(task_dir)

--- a/tools/rubric-runner/judge.py
+++ b/tools/rubric-runner/judge.py
@@ -108,7 +108,7 @@ async def judge_one(
 ) -> dict:
     """Run harbor check on one task; persist and return a small status record."""
     # Imported lazily so --help works without harbor installed.
-    from harbor.analyze.checker import run_check
+    from harbor.analyze.checker import run_check  # ty: ignore[unresolved-import]
 
     slug = task_slug(task_dir)
     task_type = detect_task_type(task_dir)


### PR DESCRIPTION
## Problem

Ten `task.toml` files under `tasks/compute-and-data/` declare `AWS_REGION` twice
within the same table. TOML rejects a redefined key, so these files fail to parse:

```
Cannot overwrite a value (at line 35, column 25)
```

The framework parses `task.toml` when it builds each task, so **every run of a
dataset containing any of these tasks aborts before a single task executes**:

```
TaskConfigInvalidError: Invalid task(s):
  .../amplify-deploy-frontend-from-s3: Cannot overwrite a value (line 35, col 25)
  .../create-eks-cluster: Cannot overwrite a value (line 52, col 70)
```

Three registry datasets are affected, since all three include these tasks:
`aws-bench-basic`, `compute-and-data`, and `all`.

The duplicates were introduced by `7214635` ("migrate compute-and-data +
streaming-and-iot to AWS_REGION"), which renamed `AWS_DEFAULT_REGION` to
`AWS_REGION` in files that already declared `AWS_REGION`.

## Changes

### 1. Remove the duplicate keys (`7621db6`)

**Nine files** carried an exact duplicate (same key, same value) in
`[pre_invoke.env]` and `[post_invoke.env]` — the redundant line is dropped. No
behavior change; the resolved value is identical.

**`create-eks-cluster`** declared `AWS_REGION` twice in `[verifier.env]` with
*differing* values. The literal `"us-east-1"` is dropped in favor of the
scenario-export placeholder `{{compute-and-data-ec2-vlf3847wf-us-east-1-AWSRegion}}`,
which the file's four other `AWS_REGION` entries (including `[solution.env]`)
already use. This restores the file's pre-rename state.

The `tasks/` diff is 19 deletions and zero insertions.

### 2. Add a parse gate (`7621db6`)

Adds `test/ci_utils/check-task-toml-parses.sh` to the `make config` gate.

This shipped because the existing `task.toml` checks match on text and never
invoke a parser — `test/test_tasks.ts` reads `[verifier.env]` keys "without a
TOML parser" and scans fields "rather than parsing TOML to keep this dep-free".
Regex cannot see a duplicate key. The new check parses every `task.toml` and
fails on any file a TOML parser rejects, catching duplicate keys, bad escapes,
and malformed inline tables/arrays.

No new dependency: `tomllib` is in the standard library from 3.11. The script
prefers `python3` and falls back to `uv`, which is already a declared
prerequisite.

### 3. Unbreak `py-typecheck` (`3686495`, `5f7bee8`)

`make check` was already failing on `main` before this branch, independently of
the task fix, so it is fixed here to get the gate green.

`tools/rubric-runner/*.py` import their siblings by bare name (`from lib import
...`, `from generate_rubrics import ...`). ty resolves modules only from its
search path, which does not include the checked file's own directory, so those
imports became unresolvable and `py-typecheck` failed with five
`unresolved-import` errors. `ty` is unpinned (`uvx ty check`), so this began
failing without any repo change.

The fix passes `--extra-search-path` for each directory named in a new
`PY_MODULE_PATHS` variable. Note that ty does **not** apply `extra-paths` from a
`[tool.ty.environment]` table in `pyproject.toml` (verified), so this is set on
the command line next to the existing `PY_TYPECHECK_PATHS`.

`5f7bee8` restores an inline `ty: ignore[unresolved-import]` on the lazy `harbor`
import that `3686495` removed in error. harbor is an external package that is
genuinely absent when ty runs, and the `[tool.ty.rules]` entry in
`pyproject.toml` does not suppress it — only the inline directive does. Net
effect: `judge.py` is unchanged from `main`.

## Verification

- The new gate fails on this branch's parent (10 of 134 files, matching the exact
  line/column from the failing runs) and passes after the fix (134/134, confirmed
  in this PR's CI log).
- `make config`, `make shell` (shellcheck clean on the new script), `make py`,
  and `make ts-test` (28/28) all pass locally; full `make check` green in CI.
- Both sync drift checks clean: `shared/judge/scripts/sync.sh --check` and
  `shared/tasks/scripts/sync.sh --check`.
- Verified through the framework's own task-loading path against a local
  checkout, before and after:

  ```
  BEFORE: TaskConfigInvalidError - 10 task(s) rejected
  AFTER:  OK - 27 tasks loaded and validated
  ```

## Follow-ups

- A registry regeneration in `aws-bench` is required to pick this up. Registry
  entries pin each task to the last commit that touched its path, so the pins
  only move once this merges. A dry run confirms exactly three entries change:
  `compute-and-data` and `aws-bench-basic` (0.7.1 -> 0.7.2) and `all`
  (0.7.2 -> 0.7.3).
- `integration-testing` carries the same 10 files and needs this fix as well.
- Consider pinning `ty` so an upstream release cannot break the gate again;
  `check-toolchain-pinning.sh` already flags floating versions as a
  runner-stability risk.