### PR TITLE
Release/llm only judge rubrics quickstart

### DIFF
--- a/shared/judge/README.md
+++ b/shared/judge/README.md
@@ -11,6 +11,8 @@ Tasks copy these into their own `tests/` directory rather than symlinking, becau
 
 `scripts/sync.sh` also runs CI drift checks for **mutation tasks** (`tests/check.py`-based, no judge files) — see `--check-output-contract` below. Those tasks don't ship the four shared judge files, but they do reuse the same sync entry point.
 
+**Customized tasks**: a task whose `judge.toml` no longer has the canonical `answers_equivalent` criterion has an intentionally per-claim rubric. `sync.sh` detects this and only syncs/checks `test.sh` and `resolve_placeholders.py` for such tasks — never `judge.toml`/`judge_prompt.md`.
+
 ## Propagating edits
 
 ```

--- a/shared/judge/resolve_placeholders.py
+++ b/shared/judge/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/shared/judge/resolve_placeholders.py
+++ b/shared/judge/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:

--- a/shared/judge/scripts/sync.sh
+++ b/shared/judge/scripts/sync.sh
@@ -5,8 +5,8 @@
 # For each such task, the four canonical files (judge_prompt.md, judge.toml,
 # test.sh, resolve_placeholders.py) are overwritten with the shared copy --
 # EXCEPT for tasks whose judge.toml/judge_prompt.md have been intentionally
-# customized by AWSBenchRubricGenerator into a per-claim rubric (no longer
-# just the canonical single "answers_equivalent" criterion). For those tasks,
+# customized into a per-claim rubric (no longer just the canonical single
+# "answers_equivalent" criterion). For those tasks,
 # only test.sh and resolve_placeholders.py are synced -- judge.toml and
 # judge_prompt.md are deliberately per-task and must never be overwritten or
 # flagged as drift. See is_customized() below for the detection rule.
@@ -387,12 +387,12 @@ fi
 
 # ── --check / sync: shared/judge/ files across all tasks ──
 # A task's judge.toml/judge_prompt.md are "customized" once a per-claim rubric
-# (from AWSBenchRubricGenerator) has replaced the canonical single
-# "answers_equivalent" criterion. Detect this without a TOML parser: the
-# canonical judge.toml always has exactly that one criterion name; any task
-# missing that exact line has been regenerated into per-claim criteria.
-# test.sh and resolve_placeholders.py are never touched by that tool, so they
-# always stay canonical regardless of whether the task's judge files were
+# has replaced the canonical single "answers_equivalent" criterion. Detect
+# this without a TOML parser: the canonical judge.toml always has exactly
+# that one criterion name; any task missing that exact line has been
+# regenerated into per-claim criteria. test.sh and resolve_placeholders.py
+# are never touched by that customization, so they always stay canonical
+# regardless of whether the task's judge files were
 # customized.
 is_customized() {
     ! grep -q '^name = "answers_equivalent"$' "$1/judge.toml" 2>/dev/null

--- a/shared/judge/scripts/sync.sh
+++ b/shared/judge/scripts/sync.sh
@@ -3,11 +3,19 @@
 #
 # A task is considered "rewardkit-based" if it has a tests/judge.toml file.
 # For each such task, the four canonical files (judge_prompt.md, judge.toml,
-# test.sh, resolve_placeholders.py) are overwritten with the shared copy.
+# test.sh, resolve_placeholders.py) are overwritten with the shared copy --
+# EXCEPT for tasks whose judge.toml/judge_prompt.md have been intentionally
+# customized by AWSBenchRubricGenerator into a per-claim rubric (no longer
+# just the canonical single "answers_equivalent" criterion). For those tasks,
+# only test.sh and resolve_placeholders.py are synced -- judge.toml and
+# judge_prompt.md are deliberately per-task and must never be overwritten or
+# flagged as drift. See is_customized() below for the detection rule.
 #
 # Modes:
 #   sync.sh                          Copy shared files into every task (default).
-#   sync.sh --check                  Verify shared files match across all tasks.
+#   sync.sh --check                  Verify shared files match across all tasks
+#                                    (customized tasks are checked only on
+#                                    test.sh/resolve_placeholders.py).
 #                                    Exits non-zero on the first diff.
 #   sync.sh --check-instructions     Verify each task's instruction.md matches
 #                                    the 'instruction' field of its
@@ -378,11 +386,32 @@ PYEOF
 fi
 
 # ── --check / sync: shared/judge/ files across all tasks ──
+# A task's judge.toml/judge_prompt.md are "customized" once a per-claim rubric
+# (from AWSBenchRubricGenerator) has replaced the canonical single
+# "answers_equivalent" criterion. Detect this without a TOML parser: the
+# canonical judge.toml always has exactly that one criterion name; any task
+# missing that exact line has been regenerated into per-claim criteria.
+# test.sh and resolve_placeholders.py are never touched by that tool, so they
+# always stay canonical regardless of whether the task's judge files were
+# customized.
+is_customized() {
+    ! grep -q '^name = "answers_equivalent"$' "$1/judge.toml" 2>/dev/null
+}
+
+ALWAYS_SYNCED_FILES=(test.sh resolve_placeholders.py)
+
 count=0
+customized_count=0
 diff_count=0
 while IFS= read -r -d '' marker; do
     task_tests_dir="$(dirname "$marker")"
-    for f in "${FILES[@]}"; do
+    if is_customized "$task_tests_dir"; then
+        customized_count=$((customized_count + 1))
+        sync_files=("${ALWAYS_SYNCED_FILES[@]}")
+    else
+        sync_files=("${FILES[@]}")
+    fi
+    for f in "${sync_files[@]}"; do
         if [[ "$MODE" == "check" ]]; then
             if ! cmp -s "$SHARED_DIR/$f" "$task_tests_dir/$f"; then
                 echo "DRIFT: $task_tests_dir/$f differs from $SHARED_DIR/$f" >&2
@@ -395,12 +424,13 @@ while IFS= read -r -d '' marker; do
     count=$((count + 1))
 done < <(find "$TASKS_DIR" -name 'judge.toml' -path '*/tests/judge.toml' -print0)
 
+canonical_count=$((count - customized_count))
 if [[ "$MODE" == "check" ]]; then
     if [[ $diff_count -gt 0 ]]; then
         echo "Found $diff_count drifted file(s) across $count task(s). Run sync.sh to fix." >&2
         exit 1
     fi
-    echo "Checked ${#FILES[@]} files in $count task(s); all in sync."
+    echo "Checked ${#FILES[@]} files in $canonical_count canonical task(s) + ${#ALWAYS_SYNCED_FILES[@]} files in $customized_count customized task(s) ($count total); all in sync."
 else
-    echo "Synced ${#FILES[@]} files into $count task(s)."
+    echo "Synced ${#FILES[@]} files into $canonical_count canonical task(s), ${#ALWAYS_SYNCED_FILES[@]} files (test.sh/resolve_placeholders.py only) into $customized_count customized task(s) ($count total)."
 fi

--- a/tasks/api-and-observability/bedrock-agentcore-runtime-missing-logs/tests/resolve_placeholders.py
+++ b/tasks/api-and-observability/bedrock-agentcore-runtime-missing-logs/tests/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/tasks/api-and-observability/bedrock-agentcore-runtime-missing-logs/tests/resolve_placeholders.py
+++ b/tasks/api-and-observability/bedrock-agentcore-runtime-missing-logs/tests/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:

--- a/tasks/api-and-observability/bedrock-kb-embedding-model-cfn-deps/tests/resolve_placeholders.py
+++ b/tasks/api-and-observability/bedrock-kb-embedding-model-cfn-deps/tests/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/tasks/api-and-observability/bedrock-kb-embedding-model-cfn-deps/tests/resolve_placeholders.py
+++ b/tasks/api-and-observability/bedrock-kb-embedding-model-cfn-deps/tests/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:

--- a/tasks/api-and-observability/cloudfront-distribution-origin-error-diagnosis/tests/resolve_placeholders.py
+++ b/tasks/api-and-observability/cloudfront-distribution-origin-error-diagnosis/tests/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/tasks/api-and-observability/cloudfront-distribution-origin-error-diagnosis/tests/resolve_placeholders.py
+++ b/tasks/api-and-observability/cloudfront-distribution-origin-error-diagnosis/tests/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:

--- a/tasks/api-and-observability/cloudfront-oac-s-forbidden-troubleshoot/tests/resolve_placeholders.py
+++ b/tasks/api-and-observability/cloudfront-oac-s-forbidden-troubleshoot/tests/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/tasks/api-and-observability/cloudfront-oac-s-forbidden-troubleshoot/tests/resolve_placeholders.py
+++ b/tasks/api-and-observability/cloudfront-oac-s-forbidden-troubleshoot/tests/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:

--- a/tasks/api-and-observability/debug-api-gateway-iam-authorization/tests/resolve_placeholders.py
+++ b/tasks/api-and-observability/debug-api-gateway-iam-authorization/tests/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/tasks/api-and-observability/debug-api-gateway-iam-authorization/tests/resolve_placeholders.py
+++ b/tasks/api-and-observability/debug-api-gateway-iam-authorization/tests/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:

--- a/tasks/api-and-observability/debug-websocket-api-backend-response/tests/resolve_placeholders.py
+++ b/tasks/api-and-observability/debug-websocket-api-backend-response/tests/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/tasks/api-and-observability/debug-websocket-api-backend-response/tests/resolve_placeholders.py
+++ b/tasks/api-and-observability/debug-websocket-api-backend-response/tests/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:

--- a/tasks/api-and-observability/diagnose-alb-five-xx-errors/tests/resolve_placeholders.py
+++ b/tasks/api-and-observability/diagnose-alb-five-xx-errors/tests/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/tasks/api-and-observability/diagnose-alb-five-xx-errors/tests/resolve_placeholders.py
+++ b/tasks/api-and-observability/diagnose-alb-five-xx-errors/tests/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:

--- a/tasks/api-and-observability/diagnose-alb-opensearch-bad-gateway/tests/resolve_placeholders.py
+++ b/tasks/api-and-observability/diagnose-alb-opensearch-bad-gateway/tests/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/tasks/api-and-observability/diagnose-alb-opensearch-bad-gateway/tests/resolve_placeholders.py
+++ b/tasks/api-and-observability/diagnose-alb-opensearch-bad-gateway/tests/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:

--- a/tasks/api-and-observability/diagnose-cloudwatch-alarm-firing/tests/resolve_placeholders.py
+++ b/tasks/api-and-observability/diagnose-cloudwatch-alarm-firing/tests/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/tasks/api-and-observability/diagnose-cloudwatch-alarm-firing/tests/resolve_placeholders.py
+++ b/tasks/api-and-observability/diagnose-cloudwatch-alarm-firing/tests/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:

--- a/tasks/api-and-observability/diagnose-onyx-lambda-processing-failure/tests/resolve_placeholders.py
+++ b/tasks/api-and-observability/diagnose-onyx-lambda-processing-failure/tests/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/tasks/api-and-observability/diagnose-onyx-lambda-processing-failure/tests/resolve_placeholders.py
+++ b/tasks/api-and-observability/diagnose-onyx-lambda-processing-failure/tests/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:

--- a/tasks/api-and-observability/diagnose-xray-service-latency-cause/tests/resolve_placeholders.py
+++ b/tasks/api-and-observability/diagnose-xray-service-latency-cause/tests/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/tasks/api-and-observability/diagnose-xray-service-latency-cause/tests/resolve_placeholders.py
+++ b/tasks/api-and-observability/diagnose-xray-service-latency-cause/tests/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:

--- a/tasks/api-and-observability/find-missing-step-functions-state-machine/tests/resolve_placeholders.py
+++ b/tasks/api-and-observability/find-missing-step-functions-state-machine/tests/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/tasks/api-and-observability/find-missing-step-functions-state-machine/tests/resolve_placeholders.py
+++ b/tasks/api-and-observability/find-missing-step-functions-state-machine/tests/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:

--- a/tasks/api-and-observability/lambda-sqs-reconciliation-no-output/tests/resolve_placeholders.py
+++ b/tasks/api-and-observability/lambda-sqs-reconciliation-no-output/tests/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/tasks/api-and-observability/lambda-sqs-reconciliation-no-output/tests/resolve_placeholders.py
+++ b/tasks/api-and-observability/lambda-sqs-reconciliation-no-output/tests/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:

--- a/tasks/api-and-observability/opensearch-check-document-request-status-logs/tests/resolve_placeholders.py
+++ b/tasks/api-and-observability/opensearch-check-document-request-status-logs/tests/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/tasks/api-and-observability/opensearch-check-document-request-status-logs/tests/resolve_placeholders.py
+++ b/tasks/api-and-observability/opensearch-check-document-request-status-logs/tests/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:

--- a/tasks/api-and-observability/opensearch-cognito-alb-timeout-diagnosis/tests/resolve_placeholders.py
+++ b/tasks/api-and-observability/opensearch-cognito-alb-timeout-diagnosis/tests/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/tasks/api-and-observability/opensearch-cognito-alb-timeout-diagnosis/tests/resolve_placeholders.py
+++ b/tasks/api-and-observability/opensearch-cognito-alb-timeout-diagnosis/tests/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:

--- a/tasks/databases-and-storage/analyze-s-intelligent-tiering-configs/tests/resolve_placeholders.py
+++ b/tasks/databases-and-storage/analyze-s-intelligent-tiering-configs/tests/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/tasks/databases-and-storage/analyze-s-intelligent-tiering-configs/tests/resolve_placeholders.py
+++ b/tasks/databases-and-storage/analyze-s-intelligent-tiering-configs/tests/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:

--- a/tasks/databases-and-storage/check-codebuild-project-nodejs-version/tests/resolve_placeholders.py
+++ b/tasks/databases-and-storage/check-codebuild-project-nodejs-version/tests/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/tasks/databases-and-storage/check-codebuild-project-nodejs-version/tests/resolve_placeholders.py
+++ b/tasks/databases-and-storage/check-codebuild-project-nodejs-version/tests/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:

--- a/tasks/databases-and-storage/check-s-bucket-access-profiles/tests/resolve_placeholders.py
+++ b/tasks/databases-and-storage/check-s-bucket-access-profiles/tests/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/tasks/databases-and-storage/check-s-bucket-access-profiles/tests/resolve_placeholders.py
+++ b/tasks/databases-and-storage/check-s-bucket-access-profiles/tests/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:

--- a/tasks/databases-and-storage/check-s-vector-bucket-indexes-exist/tests/resolve_placeholders.py
+++ b/tasks/databases-and-storage/check-s-vector-bucket-indexes-exist/tests/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/tasks/databases-and-storage/check-s-vector-bucket-indexes-exist/tests/resolve_placeholders.py
+++ b/tasks/databases-and-storage/check-s-vector-bucket-indexes-exist/tests/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:

--- a/tasks/databases-and-storage/cloudformation-top-stacks-resource-breakdown/tests/resolve_placeholders.py
+++ b/tasks/databases-and-storage/cloudformation-top-stacks-resource-breakdown/tests/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/tasks/databases-and-storage/cloudformation-top-stacks-resource-breakdown/tests/resolve_placeholders.py
+++ b/tasks/databases-and-storage/cloudformation-top-stacks-resource-breakdown/tests/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:

--- a/tasks/databases-and-storage/compare-s-bucket-structure-sizes/tests/resolve_placeholders.py
+++ b/tasks/databases-and-storage/compare-s-bucket-structure-sizes/tests/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/tasks/databases-and-storage/compare-s-bucket-structure-sizes/tests/resolve_placeholders.py
+++ b/tasks/databases-and-storage/compare-s-bucket-structure-sizes/tests/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:

--- a/tasks/databases-and-storage/count-cfn-stacks-with-s-buckets/tests/resolve_placeholders.py
+++ b/tasks/databases-and-storage/count-cfn-stacks-with-s-buckets/tests/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/tasks/databases-and-storage/count-cfn-stacks-with-s-buckets/tests/resolve_placeholders.py
+++ b/tasks/databases-and-storage/count-cfn-stacks-with-s-buckets/tests/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:

--- a/tasks/databases-and-storage/count-old-s-buckets/tests/resolve_placeholders.py
+++ b/tasks/databases-and-storage/count-old-s-buckets/tests/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/tasks/databases-and-storage/count-old-s-buckets/tests/resolve_placeholders.py
+++ b/tasks/databases-and-storage/count-old-s-buckets/tests/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:

--- a/tasks/databases-and-storage/count-sns-topic-sqs-subscribers/tests/resolve_placeholders.py
+++ b/tasks/databases-and-storage/count-sns-topic-sqs-subscribers/tests/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/tasks/databases-and-storage/count-sns-topic-sqs-subscribers/tests/resolve_placeholders.py
+++ b/tasks/databases-and-storage/count-sns-topic-sqs-subscribers/tests/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:

--- a/tasks/databases-and-storage/count-windows-server-managed-nodes/tests/resolve_placeholders.py
+++ b/tasks/databases-and-storage/count-windows-server-managed-nodes/tests/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/tasks/databases-and-storage/count-windows-server-managed-nodes/tests/resolve_placeholders.py
+++ b/tasks/databases-and-storage/count-windows-server-managed-nodes/tests/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:

--- a/tasks/databases-and-storage/dynamodb-query-workflow-status-analysis/tests/resolve_placeholders.py
+++ b/tasks/databases-and-storage/dynamodb-query-workflow-status-analysis/tests/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/tasks/databases-and-storage/dynamodb-query-workflow-status-analysis/tests/resolve_placeholders.py
+++ b/tasks/databases-and-storage/dynamodb-query-workflow-status-analysis/tests/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:

--- a/tasks/databases-and-storage/dynamodb-scan-and-fetch-record/tests/resolve_placeholders.py
+++ b/tasks/databases-and-storage/dynamodb-scan-and-fetch-record/tests/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/tasks/databases-and-storage/dynamodb-scan-and-fetch-record/tests/resolve_placeholders.py
+++ b/tasks/databases-and-storage/dynamodb-scan-and-fetch-record/tests/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:

--- a/tasks/databases-and-storage/dynamodb-scan-filter-by-attribute/tests/resolve_placeholders.py
+++ b/tasks/databases-and-storage/dynamodb-scan-filter-by-attribute/tests/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/tasks/databases-and-storage/dynamodb-scan-filter-by-attribute/tests/resolve_placeholders.py
+++ b/tasks/databases-and-storage/dynamodb-scan-filter-by-attribute/tests/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:

--- a/tasks/databases-and-storage/dynamodb-tables-resource-based-policy/tests/resolve_placeholders.py
+++ b/tasks/databases-and-storage/dynamodb-tables-resource-based-policy/tests/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/tasks/databases-and-storage/dynamodb-tables-resource-based-policy/tests/resolve_placeholders.py
+++ b/tasks/databases-and-storage/dynamodb-tables-resource-based-policy/tests/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:

--- a/tasks/databases-and-storage/estimate-ec-running-instance-costs/tests/resolve_placeholders.py
+++ b/tasks/databases-and-storage/estimate-ec-running-instance-costs/tests/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/tasks/databases-and-storage/estimate-ec-running-instance-costs/tests/resolve_placeholders.py
+++ b/tasks/databases-and-storage/estimate-ec-running-instance-costs/tests/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:

--- a/tasks/databases-and-storage/get-s-bucket-ownership-controls/tests/resolve_placeholders.py
+++ b/tasks/databases-and-storage/get-s-bucket-ownership-controls/tests/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/tasks/databases-and-storage/get-s-bucket-ownership-controls/tests/resolve_placeholders.py
+++ b/tasks/databases-and-storage/get-s-bucket-ownership-controls/tests/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:

--- a/tasks/databases-and-storage/glue-database-tables-schema-details/tests/resolve_placeholders.py
+++ b/tasks/databases-and-storage/glue-database-tables-schema-details/tests/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/tasks/databases-and-storage/glue-database-tables-schema-details/tests/resolve_placeholders.py
+++ b/tasks/databases-and-storage/glue-database-tables-schema-details/tests/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:

--- a/tasks/databases-and-storage/investigate-athena-table-creation-origin/tests/resolve_placeholders.py
+++ b/tasks/databases-and-storage/investigate-athena-table-creation-origin/tests/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/tasks/databases-and-storage/investigate-athena-table-creation-origin/tests/resolve_placeholders.py
+++ b/tasks/databases-and-storage/investigate-athena-table-creation-origin/tests/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:

--- a/tasks/databases-and-storage/list-buckets-with-lifecycle-policy/tests/resolve_placeholders.py
+++ b/tasks/databases-and-storage/list-buckets-with-lifecycle-policy/tests/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/tasks/databases-and-storage/list-buckets-with-lifecycle-policy/tests/resolve_placeholders.py
+++ b/tasks/databases-and-storage/list-buckets-with-lifecycle-policy/tests/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:

--- a/tasks/databases-and-storage/list-dynamodb-kinesis-streams-all-regions/tests/resolve_placeholders.py
+++ b/tasks/databases-and-storage/list-dynamodb-kinesis-streams-all-regions/tests/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/tasks/databases-and-storage/list-dynamodb-kinesis-streams-all-regions/tests/resolve_placeholders.py
+++ b/tasks/databases-and-storage/list-dynamodb-kinesis-streams-all-regions/tests/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:

--- a/tasks/databases-and-storage/list-dynamodb-tables-all-regions/tests/resolve_placeholders.py
+++ b/tasks/databases-and-storage/list-dynamodb-tables-all-regions/tests/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/tasks/databases-and-storage/list-dynamodb-tables-all-regions/tests/resolve_placeholders.py
+++ b/tasks/databases-and-storage/list-dynamodb-tables-all-regions/tests/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:

--- a/tasks/databases-and-storage/list-s-bucket-subdirectories/tests/resolve_placeholders.py
+++ b/tasks/databases-and-storage/list-s-bucket-subdirectories/tests/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/tasks/databases-and-storage/list-s-bucket-subdirectories/tests/resolve_placeholders.py
+++ b/tasks/databases-and-storage/list-s-bucket-subdirectories/tests/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:

--- a/tasks/databases-and-storage/list-waf-webacl-findings/tests/resolve_placeholders.py
+++ b/tasks/databases-and-storage/list-waf-webacl-findings/tests/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/tasks/databases-and-storage/list-waf-webacl-findings/tests/resolve_placeholders.py
+++ b/tasks/databases-and-storage/list-waf-webacl-findings/tests/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:

--- a/tasks/databases-and-storage/query-dynamodb-filtered-records-count/tests/resolve_placeholders.py
+++ b/tasks/databases-and-storage/query-dynamodb-filtered-records-count/tests/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/tasks/databases-and-storage/query-dynamodb-filtered-records-count/tests/resolve_placeholders.py
+++ b/tasks/databases-and-storage/query-dynamodb-filtered-records-count/tests/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:

--- a/tasks/databases-and-storage/report-unencrypted-s-buckets/tests/resolve_placeholders.py
+++ b/tasks/databases-and-storage/report-unencrypted-s-buckets/tests/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/tasks/databases-and-storage/report-unencrypted-s-buckets/tests/resolve_placeholders.py
+++ b/tasks/databases-and-storage/report-unencrypted-s-buckets/tests/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:

--- a/tasks/databases-and-storage/retrieve-s-csv-object-contents/tests/resolve_placeholders.py
+++ b/tasks/databases-and-storage/retrieve-s-csv-object-contents/tests/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/tasks/databases-and-storage/retrieve-s-csv-object-contents/tests/resolve_placeholders.py
+++ b/tasks/databases-and-storage/retrieve-s-csv-object-contents/tests/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:

--- a/tasks/databases-and-storage/retrieve-s-text-file-contents/tests/resolve_placeholders.py
+++ b/tasks/databases-and-storage/retrieve-s-text-file-contents/tests/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/tasks/databases-and-storage/retrieve-s-text-file-contents/tests/resolve_placeholders.py
+++ b/tasks/databases-and-storage/retrieve-s-text-file-contents/tests/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:

--- a/tasks/databases-and-storage/s-download-csv-identify-columns/tests/resolve_placeholders.py
+++ b/tasks/databases-and-storage/s-download-csv-identify-columns/tests/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/tasks/databases-and-storage/s-download-csv-identify-columns/tests/resolve_placeholders.py
+++ b/tasks/databases-and-storage/s-download-csv-identify-columns/tests/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:

--- a/tasks/databases-and-storage/s-object-versions-and-metadata/tests/resolve_placeholders.py
+++ b/tasks/databases-and-storage/s-object-versions-and-metadata/tests/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/tasks/databases-and-storage/s-object-versions-and-metadata/tests/resolve_placeholders.py
+++ b/tasks/databases-and-storage/s-object-versions-and-metadata/tests/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:

--- a/tasks/databases-and-storage/scan-dynamodb-table-by-status/tests/resolve_placeholders.py
+++ b/tasks/databases-and-storage/scan-dynamodb-table-by-status/tests/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/tasks/databases-and-storage/scan-dynamodb-table-by-status/tests/resolve_placeholders.py
+++ b/tasks/databases-and-storage/scan-dynamodb-table-by-status/tests/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:

--- a/tasks/ec2-multiregion/describe-cloudformation-stack-resources/tests/judge.toml
+++ b/tasks/ec2-multiregion/describe-cloudformation-stack-resources/tests/judge.toml
@@ -5,9 +5,54 @@ files = [
     "/tests/ground_truth.json",
 ]
 prompt_template = "judge_prompt.md"
-mode = "individual"
+mode = "batched"
 
 [[criterion]]
-name = "answers_equivalent"
-description = "Are the junior engineer's findings equivalent to the senior engineer's reference answer per the rubric?"
+name = "the_stack_ec2_multiregion_ec2_ls9fuhb522_us_west"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The stack {{ec2-multiregion-EC2-ls9fuhb522-us-west-1-StackId}} in us-west-1 is a CDK stack."
+type = "binary"
+
+[[criterion]]
+name = "the_stack_ec2_multiregion_ec2_ls9fuhb522_us_west_2"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The stack {{ec2-multiregion-EC2-ls9fuhb522-us-west-1-StackId}} contains a VPC."
+type = "binary"
+
+[[criterion]]
+name = "the_stack_ec2_multiregion_ec2_ls9fuhb522_us_west_3"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The stack {{ec2-multiregion-EC2-ls9fuhb522-us-west-1-StackId}} contains a public subnet."
+type = "binary"
+
+[[criterion]]
+name = "the_stack_ec2_multiregion_ec2_ls9fuhb522_us_west_4"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The stack {{ec2-multiregion-EC2-ls9fuhb522-us-west-1-StackId}} contains an EC2 instance {{ec2-multiregion-EC2-ls9fuhb522-us-west-1-InstanceId}}."
+type = "binary"
+
+[[criterion]]
+name = "the_stack_ec2_multiregion_ec2_ls9fuhb522_us_west_5"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The stack {{ec2-multiregion-EC2-ls9fuhb522-us-west-1-StackId}} contains a security group for the EC2 instance."
+type = "binary"
+
+[[criterion]]
+name = "the_stack_ec2_multiregion_ec2_ls9fuhb522_us_west_6"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The stack {{ec2-multiregion-EC2-ls9fuhb522-us-west-1-StackId}} contains an IAM role."
+type = "binary"
+
+[[criterion]]
+name = "the_stack_ec2_multiregion_ec2_ls9fuhb522_us_west_7"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The stack {{ec2-multiregion-EC2-ls9fuhb522-us-west-1-StackId}} contains a Lambda-backed custom resource that locks down the default security group."
+type = "binary"
+
+[[criterion]]
+name = "the_stack_ec2_multiregion_ec2_ls9fuhb522_us_west_8"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The stack {{ec2-multiregion-EC2-ls9fuhb522-us-west-1-StackId}} has 16 resources in total."
+type = "binary"
+
+[[criterion]]
+name = "all_resources_in_the_stack_ec2_multiregion_ec2_l"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): All resources in the stack {{ec2-multiregion-EC2-ls9fuhb522-us-west-1-StackId}} were created successfully."
+type = "binary"
+
+[[criterion]]
+name = "no_extraneous_or_contradicting_facts"
+description = "Per the rubric's Fail-If and Clarifications rules, does the junior engineer's answer AVOID both of the following: (1) stating any fact that contradicts the reference answer's stated infrastructure state (e.g. a different count, the wrong resource, an opposite status), and (2) claiming the existence of additional resources, findings, or facts beyond what the reference answer states, in a way that would mislead a practitioner into a different conclusion or action. Judge the junior's answer as a whole against the entire reference answer for this, not any single claim. Answer 'yes' if the junior's answer contains no such contradiction or unsupported extra claim; answer 'no' if it does."
 type = "binary"

--- a/tasks/ec2-multiregion/describe-cloudformation-stack-resources/tests/judge_prompt.md
+++ b/tasks/ec2-multiregion/describe-cloudformation-stack-resources/tests/judge_prompt.md
@@ -7,25 +7,27 @@ You will be shown two files in the user message:
    - `instruction`: the task itself (what the user asked).
    - `expected_answer`: the senior engineer's reference answer.
 
-## Evaluation Standard
+## General Guidance
+
+### Evaluation Standard
 
 The answers are EQUIVALENT if a practitioner following the junior's answer would reach the same conclusion and take the same effective action as someone following the senior's answer.
 
-## Must Match
+### Must Match
 
 - The primary root cause or diagnosis.
 - The overall verdict (broken/working, how many, which resource).
 - All distinct root causes if the senior identifies multiple.
 - If a fix is proposed: it must actually work. A command missing required parameters or targeting the wrong resource is NOT equivalent, even if the diagnosis is correct.
 
-## May Differ
+### May Differ
 
 - Wording, formatting, level of detail, or method of investigation.
 - Console URLs, dashboard links, retention periods, region names when obvious.
 - Additional correct information beyond the reference.
 - Formatting details of identifiers when the resource is unambiguously identified.
 
-## Fail If
+### Fail If
 
 1. Wrong verdict (broken vs working).
 2. Wrong root cause that would not explain or fix the problem.
@@ -34,19 +36,27 @@ The answers are EQUIVALENT if a practitioner following the junior's answer would
 5. Missing a primary root cause the senior identified.
 6. Introduces false claims about the infrastructure that would mislead a practitioner. Minor imprecisions in non-actionable details do not count.
 
-## Clarifications
+### Clarifications
 
 - Omitting a detail is acceptable UNLESS it changes what action a practitioner would take.
 - Merely mentioning an approach is not the same as providing it as the solution.
 - Listing more resources than the reference says exist is NOT equivalent.
 - If the junior answers with a question and the senior gives an explicit answer, NOT equivalent.
 
-## Steps
+### Steps
 
 1. Read the instruction to understand what was asked.
 2. Identify what action a practitioner would take from the senior's answer.
 3. Check if the junior's answer leads to the same effective action.
 4. Check if any Fail condition applies.
 5. If same effective action and no fail condition: EQUIVALENT.
+
+## Per-Claim Grading
+
+This task's reference answer has been decomposed into the individual claims listed below. Score each claim independently, on its own merits -- whether the junior's answer covers other listed claims should not affect this one.
+
+- For each claim, judge whether the junior's answer in agent-output.txt supports it, allowing for differences in wording, formatting, or level of detail per the Must Match / May Differ / Fail If rules above.
+- A claim about a fix or remediation step is satisfied when the junior proposes an equivalent fix; a claim about a root cause is satisfied when the junior identifies an equivalent cause.
+- EXCEPTION: the claim named `no_extraneous_or_contradicting_facts` (if listed below) is judged differently from every other claim here -- follow its own description, which judges the answer as a WHOLE against the ENTIRE reference answer, not one isolated fact.
 
 {criteria}

--- a/tasks/ec2-multiregion/describe-cloudformation-stack-resources/tests/resolve_placeholders.py
+++ b/tasks/ec2-multiregion/describe-cloudformation-stack-resources/tests/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/tasks/ec2-multiregion/describe-cloudformation-stack-resources/tests/resolve_placeholders.py
+++ b/tasks/ec2-multiregion/describe-cloudformation-stack-resources/tests/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:

--- a/tasks/ec2-multiregion/describe-ec-instances-cross-region-connectivity/tests/judge.toml
+++ b/tasks/ec2-multiregion/describe-ec-instances-cross-region-connectivity/tests/judge.toml
@@ -5,9 +5,34 @@ files = [
     "/tests/ground_truth.json",
 ]
 prompt_template = "judge_prompt.md"
-mode = "individual"
+mode = "batched"
 
 [[criterion]]
-name = "answers_equivalent"
-description = "Are the junior engineer's findings equivalent to the senior engineer's reference answer per the rubric?"
+name = "there_are_ec2_multiregion_ec2_ks84v1fh12_us_east"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): There are {{ec2-multiregion-EC2-ks84v1fh12-us-east-1-NUMEC2Running}} EC2 instances in us-east-1"
+type = "binary"
+
+[[criterion]]
+name = "there_are_ec2_multiregion_ec2_ls9fuhb522_us_west"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): There are {{ec2-multiregion-EC2-ls9fuhb522-us-west-1-NUMEC2Running}} EC2 instances in us-west-1"
+type = "binary"
+
+[[criterion]]
+name = "there_are_ec2_multiregion_ec2_ls9fuhb522_us_west_2"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): There are {{ec2-multiregion-EC2-ls9fuhb522-us-west-2-NUMEC2Running}} EC2 instances in us-west-2"
+type = "binary"
+
+[[criterion]]
+name = "instances_ec2_multiregion_ec2_ks84v1fh12_us_east"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): Instances {{ec2-multiregion-EC2-ks84v1fh12-us-east-1-InstanceId}}, {{ec2-multiregion-EC2-ks84v1fh12-us-east-1-LaunchTemplateInstanceId}}, and {{ec2-multiregion-EC2-ks84v1fh12-us-east-1-PrivateInstanceId}} are in VPC {{ec2-multiregion-EC2-ks84v1fh12-us-east-1-VpcId}}"
+type = "binary"
+
+[[criterion]]
+name = "the_remaining_instance_in_us_east_1_is_in_the_de"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The remaining instance in us-east-1 is not in the same VPC as (not network-adjacent to) the other three instances. The reference answer additionally notes this VPC is the account's default VPC -- do not require the junior to use the words 'default VPC' or otherwise identify it as default; crediting the substantive non-adjacency fact is sufficient."
+type = "binary"
+
+[[criterion]]
+name = "no_extraneous_or_contradicting_facts"
+description = "Per the rubric's Fail-If and Clarifications rules, does the junior engineer's answer AVOID both of the following: (1) stating any fact that contradicts the reference answer's stated infrastructure state (e.g. a different count, the wrong resource, an opposite status), and (2) claiming the existence of additional resources, findings, or facts beyond what the reference answer states, in a way that would mislead a practitioner into a different conclusion or action. Judge the junior's answer as a whole against the entire reference answer for this, not any single claim. Answer 'yes' if the junior's answer contains no such contradiction or unsupported extra claim; answer 'no' if it does."
 type = "binary"

--- a/tasks/ec2-multiregion/describe-ec-instances-cross-region-connectivity/tests/judge_prompt.md
+++ b/tasks/ec2-multiregion/describe-ec-instances-cross-region-connectivity/tests/judge_prompt.md
@@ -7,25 +7,27 @@ You will be shown two files in the user message:
    - `instruction`: the task itself (what the user asked).
    - `expected_answer`: the senior engineer's reference answer.
 
-## Evaluation Standard
+## General Guidance
+
+### Evaluation Standard
 
 The answers are EQUIVALENT if a practitioner following the junior's answer would reach the same conclusion and take the same effective action as someone following the senior's answer.
 
-## Must Match
+### Must Match
 
 - The primary root cause or diagnosis.
 - The overall verdict (broken/working, how many, which resource).
 - All distinct root causes if the senior identifies multiple.
 - If a fix is proposed: it must actually work. A command missing required parameters or targeting the wrong resource is NOT equivalent, even if the diagnosis is correct.
 
-## May Differ
+### May Differ
 
 - Wording, formatting, level of detail, or method of investigation.
 - Console URLs, dashboard links, retention periods, region names when obvious.
 - Additional correct information beyond the reference.
 - Formatting details of identifiers when the resource is unambiguously identified.
 
-## Fail If
+### Fail If
 
 1. Wrong verdict (broken vs working).
 2. Wrong root cause that would not explain or fix the problem.
@@ -34,19 +36,27 @@ The answers are EQUIVALENT if a practitioner following the junior's answer would
 5. Missing a primary root cause the senior identified.
 6. Introduces false claims about the infrastructure that would mislead a practitioner. Minor imprecisions in non-actionable details do not count.
 
-## Clarifications
+### Clarifications
 
 - Omitting a detail is acceptable UNLESS it changes what action a practitioner would take.
 - Merely mentioning an approach is not the same as providing it as the solution.
 - Listing more resources than the reference says exist is NOT equivalent.
 - If the junior answers with a question and the senior gives an explicit answer, NOT equivalent.
 
-## Steps
+### Steps
 
 1. Read the instruction to understand what was asked.
 2. Identify what action a practitioner would take from the senior's answer.
 3. Check if the junior's answer leads to the same effective action.
 4. Check if any Fail condition applies.
 5. If same effective action and no fail condition: EQUIVALENT.
+
+## Per-Claim Grading
+
+This task's reference answer has been decomposed into the individual claims listed below. Score each claim independently, on its own merits -- whether the junior's answer covers other listed claims should not affect this one.
+
+- For each claim, judge whether the junior's answer in agent-output.txt supports it, allowing for differences in wording, formatting, or level of detail per the Must Match / May Differ / Fail If rules above.
+- A claim about a fix or remediation step is satisfied when the junior proposes an equivalent fix; a claim about a root cause is satisfied when the junior identifies an equivalent cause.
+- EXCEPTION: the claim named `no_extraneous_or_contradicting_facts` (if listed below) is judged differently from every other claim here -- follow its own description, which judges the answer as a WHOLE against the ENTIRE reference answer, not one isolated fact.
 
 {criteria}

--- a/tasks/ec2-multiregion/describe-ec-instances-cross-region-connectivity/tests/resolve_placeholders.py
+++ b/tasks/ec2-multiregion/describe-ec-instances-cross-region-connectivity/tests/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/tasks/ec2-multiregion/describe-ec-instances-cross-region-connectivity/tests/resolve_placeholders.py
+++ b/tasks/ec2-multiregion/describe-ec-instances-cross-region-connectivity/tests/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:

--- a/tasks/ec2-multiregion/ec-instances-without-default-vpc/tests/judge.toml
+++ b/tasks/ec2-multiregion/ec-instances-without-default-vpc/tests/judge.toml
@@ -5,9 +5,34 @@ files = [
     "/tests/ground_truth.json",
 ]
 prompt_template = "judge_prompt.md"
-mode = "individual"
+mode = "batched"
 
 [[criterion]]
-name = "answers_equivalent"
-description = "Are the junior engineer's findings equivalent to the senior engineer's reference answer per the rubric?"
+name = "ec2_multiregion_ec2_ks84v1fh12_us_east_1_instanc"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): {{ec2-multiregion-EC2-ks84v1fh12-us-east-1-InstanceId}} in us-east-1 is not associated with a default VPC"
+type = "binary"
+
+[[criterion]]
+name = "ec2_multiregion_ec2_ks84v1fh12_us_east_1_launcht"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): {{ec2-multiregion-EC2-ks84v1fh12-us-east-1-LaunchTemplateInstanceId}} in us-east-1 is not associated with a default VPC"
+type = "binary"
+
+[[criterion]]
+name = "ec2_multiregion_ec2_ks84v1fh12_us_east_1_private"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): {{ec2-multiregion-EC2-ks84v1fh12-us-east-1-PrivateInstanceId}} in us-east-1 is not associated with a default VPC"
+type = "binary"
+
+[[criterion]]
+name = "ec2_multiregion_ec2_ls9fuhb522_us_west_1_instanc"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): {{ec2-multiregion-EC2-ls9fuhb522-us-west-1-InstanceId}} in us-west-1 is not associated with a default VPC"
+type = "binary"
+
+[[criterion]]
+name = "ec2_multiregion_ec2_ls9fuhb522_us_west_2_instanc"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): {{ec2-multiregion-EC2-ls9fuhb522-us-west-2-InstanceId}} in us-west-2 is not associated with a default VPC"
+type = "binary"
+
+[[criterion]]
+name = "no_extraneous_or_contradicting_facts"
+description = "Per the rubric's Fail-If and Clarifications rules, does the junior engineer's answer AVOID both of the following: (1) stating any fact that contradicts the reference answer's stated infrastructure state (e.g. a different count, the wrong resource, an opposite status), and (2) claiming the existence of additional resources, findings, or facts beyond what the reference answer states, in a way that would mislead a practitioner into a different conclusion or action. Judge the junior's answer as a whole against the entire reference answer for this, not any single claim. Answer 'yes' if the junior's answer contains no such contradiction or unsupported extra claim; answer 'no' if it does."
 type = "binary"

--- a/tasks/ec2-multiregion/ec-instances-without-default-vpc/tests/judge_prompt.md
+++ b/tasks/ec2-multiregion/ec-instances-without-default-vpc/tests/judge_prompt.md
@@ -7,25 +7,27 @@ You will be shown two files in the user message:
    - `instruction`: the task itself (what the user asked).
    - `expected_answer`: the senior engineer's reference answer.
 
-## Evaluation Standard
+## General Guidance
+
+### Evaluation Standard
 
 The answers are EQUIVALENT if a practitioner following the junior's answer would reach the same conclusion and take the same effective action as someone following the senior's answer.
 
-## Must Match
+### Must Match
 
 - The primary root cause or diagnosis.
 - The overall verdict (broken/working, how many, which resource).
 - All distinct root causes if the senior identifies multiple.
 - If a fix is proposed: it must actually work. A command missing required parameters or targeting the wrong resource is NOT equivalent, even if the diagnosis is correct.
 
-## May Differ
+### May Differ
 
 - Wording, formatting, level of detail, or method of investigation.
 - Console URLs, dashboard links, retention periods, region names when obvious.
 - Additional correct information beyond the reference.
 - Formatting details of identifiers when the resource is unambiguously identified.
 
-## Fail If
+### Fail If
 
 1. Wrong verdict (broken vs working).
 2. Wrong root cause that would not explain or fix the problem.
@@ -34,19 +36,27 @@ The answers are EQUIVALENT if a practitioner following the junior's answer would
 5. Missing a primary root cause the senior identified.
 6. Introduces false claims about the infrastructure that would mislead a practitioner. Minor imprecisions in non-actionable details do not count.
 
-## Clarifications
+### Clarifications
 
 - Omitting a detail is acceptable UNLESS it changes what action a practitioner would take.
 - Merely mentioning an approach is not the same as providing it as the solution.
 - Listing more resources than the reference says exist is NOT equivalent.
 - If the junior answers with a question and the senior gives an explicit answer, NOT equivalent.
 
-## Steps
+### Steps
 
 1. Read the instruction to understand what was asked.
 2. Identify what action a practitioner would take from the senior's answer.
 3. Check if the junior's answer leads to the same effective action.
 4. Check if any Fail condition applies.
 5. If same effective action and no fail condition: EQUIVALENT.
+
+## Per-Claim Grading
+
+This task's reference answer has been decomposed into the individual claims listed below. Score each claim independently, on its own merits -- whether the junior's answer covers other listed claims should not affect this one.
+
+- For each claim, judge whether the junior's answer in agent-output.txt supports it, allowing for differences in wording, formatting, or level of detail per the Must Match / May Differ / Fail If rules above.
+- A claim about a fix or remediation step is satisfied when the junior proposes an equivalent fix; a claim about a root cause is satisfied when the junior identifies an equivalent cause.
+- EXCEPTION: the claim named `no_extraneous_or_contradicting_facts` (if listed below) is judged differently from every other claim here -- follow its own description, which judges the answer as a WHOLE against the ENTIRE reference answer, not one isolated fact.
 
 {criteria}

--- a/tasks/ec2-multiregion/ec-instances-without-default-vpc/tests/resolve_placeholders.py
+++ b/tasks/ec2-multiregion/ec-instances-without-default-vpc/tests/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/tasks/ec2-multiregion/ec-instances-without-default-vpc/tests/resolve_placeholders.py
+++ b/tasks/ec2-multiregion/ec-instances-without-default-vpc/tests/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:

--- a/tasks/ec2-multiregion/find-ec-instances-in-public-subnets/tests/judge.toml
+++ b/tasks/ec2-multiregion/find-ec-instances-in-public-subnets/tests/judge.toml
@@ -5,9 +5,34 @@ files = [
     "/tests/ground_truth.json",
 ]
 prompt_template = "judge_prompt.md"
-mode = "individual"
+mode = "batched"
 
 [[criterion]]
-name = "answers_equivalent"
-description = "Are the junior engineer's findings equivalent to the senior engineer's reference answer per the rubric?"
+name = "ec2_multiregion_ec2_ks84v1fh12_us_east_1_instanc"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): {{ec2-multiregion-EC2-ks84v1fh12-us-east-1-InstanceId}} is an EC2 instance in a public subnet in the us-east-1 region"
+type = "binary"
+
+[[criterion]]
+name = "ec2_multiregion_ec2_ks84v1fh12_us_east_1_launcht"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): {{ec2-multiregion-EC2-ks84v1fh12-us-east-1-LaunchTemplateInstanceId}} is an EC2 instance in a public subnet in the us-east-1 region"
+type = "binary"
+
+[[criterion]]
+name = "ec2_multiregion_ec2_ks84v1fh12_us_east_1_default"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): {{ec2-multiregion-EC2-ks84v1fh12-us-east-1-DefaultVPCInstanceId}} is an EC2 instance in a public subnet in the us-east-1 region"
+type = "binary"
+
+[[criterion]]
+name = "ec2_multiregion_ec2_ls9fuhb522_us_west_1_instanc"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): {{ec2-multiregion-EC2-ls9fuhb522-us-west-1-InstanceId}} is an EC2 instance in a public subnet in the us-west-1 region"
+type = "binary"
+
+[[criterion]]
+name = "ec2_multiregion_ec2_ls9fuhb522_us_west_2_instanc"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): {{ec2-multiregion-EC2-ls9fuhb522-us-west-2-InstanceId}} is an EC2 instance in a public subnet in the us-west-2 region"
+type = "binary"
+
+[[criterion]]
+name = "no_extraneous_or_contradicting_facts"
+description = "Per the rubric's Fail-If and Clarifications rules, does the junior engineer's answer AVOID both of the following: (1) stating any fact that contradicts the reference answer's stated infrastructure state (e.g. a different count, the wrong resource, an opposite status), and (2) claiming the existence of additional resources, findings, or facts beyond what the reference answer states, in a way that would mislead a practitioner into a different conclusion or action. Judge the junior's answer as a whole against the entire reference answer for this, not any single claim. Answer 'yes' if the junior's answer contains no such contradiction or unsupported extra claim; answer 'no' if it does."
 type = "binary"

--- a/tasks/ec2-multiregion/find-ec-instances-in-public-subnets/tests/judge_prompt.md
+++ b/tasks/ec2-multiregion/find-ec-instances-in-public-subnets/tests/judge_prompt.md
@@ -7,25 +7,27 @@ You will be shown two files in the user message:
    - `instruction`: the task itself (what the user asked).
    - `expected_answer`: the senior engineer's reference answer.
 
-## Evaluation Standard
+## General Guidance
+
+### Evaluation Standard
 
 The answers are EQUIVALENT if a practitioner following the junior's answer would reach the same conclusion and take the same effective action as someone following the senior's answer.
 
-## Must Match
+### Must Match
 
 - The primary root cause or diagnosis.
 - The overall verdict (broken/working, how many, which resource).
 - All distinct root causes if the senior identifies multiple.
 - If a fix is proposed: it must actually work. A command missing required parameters or targeting the wrong resource is NOT equivalent, even if the diagnosis is correct.
 
-## May Differ
+### May Differ
 
 - Wording, formatting, level of detail, or method of investigation.
 - Console URLs, dashboard links, retention periods, region names when obvious.
 - Additional correct information beyond the reference.
 - Formatting details of identifiers when the resource is unambiguously identified.
 
-## Fail If
+### Fail If
 
 1. Wrong verdict (broken vs working).
 2. Wrong root cause that would not explain or fix the problem.
@@ -34,19 +36,27 @@ The answers are EQUIVALENT if a practitioner following the junior's answer would
 5. Missing a primary root cause the senior identified.
 6. Introduces false claims about the infrastructure that would mislead a practitioner. Minor imprecisions in non-actionable details do not count.
 
-## Clarifications
+### Clarifications
 
 - Omitting a detail is acceptable UNLESS it changes what action a practitioner would take.
 - Merely mentioning an approach is not the same as providing it as the solution.
 - Listing more resources than the reference says exist is NOT equivalent.
 - If the junior answers with a question and the senior gives an explicit answer, NOT equivalent.
 
-## Steps
+### Steps
 
 1. Read the instruction to understand what was asked.
 2. Identify what action a practitioner would take from the senior's answer.
 3. Check if the junior's answer leads to the same effective action.
 4. Check if any Fail condition applies.
 5. If same effective action and no fail condition: EQUIVALENT.
+
+## Per-Claim Grading
+
+This task's reference answer has been decomposed into the individual claims listed below. Score each claim independently, on its own merits -- whether the junior's answer covers other listed claims should not affect this one.
+
+- For each claim, judge whether the junior's answer in agent-output.txt supports it, allowing for differences in wording, formatting, or level of detail per the Must Match / May Differ / Fail If rules above.
+- A claim about a fix or remediation step is satisfied when the junior proposes an equivalent fix; a claim about a root cause is satisfied when the junior identifies an equivalent cause.
+- EXCEPTION: the claim named `no_extraneous_or_contradicting_facts` (if listed below) is judged differently from every other claim here -- follow its own description, which judges the answer as a WHOLE against the ENTIRE reference answer, not one isolated fact.
 
 {criteria}

--- a/tasks/ec2-multiregion/find-ec-instances-in-public-subnets/tests/resolve_placeholders.py
+++ b/tasks/ec2-multiregion/find-ec-instances-in-public-subnets/tests/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/tasks/ec2-multiregion/find-ec-instances-in-public-subnets/tests/resolve_placeholders.py
+++ b/tasks/ec2-multiregion/find-ec-instances-in-public-subnets/tests/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:

--- a/tasks/ec2-multiregion/list-ec-instances-all-regions-1/tests/judge.toml
+++ b/tasks/ec2-multiregion/list-ec-instances-all-regions-1/tests/judge.toml
@@ -5,9 +5,24 @@ files = [
     "/tests/ground_truth.json",
 ]
 prompt_template = "judge_prompt.md"
-mode = "individual"
+mode = "batched"
 
 [[criterion]]
-name = "answers_equivalent"
-description = "Are the junior engineer's findings equivalent to the senior engineer's reference answer per the rubric?"
+name = "ec2_multiregion_ec2_ks84v1fh12_us_east_1_launcht"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): {{ec2-multiregion-EC2-ks84v1fh12-us-east-1-LaunchTemplateInstanceId}} is SSH-reachable from the internet"
+type = "binary"
+
+[[criterion]]
+name = "ec2_multiregion_ec2_ks84v1fh12_us_east_1_instanc"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): {{ec2-multiregion-EC2-ks84v1fh12-us-east-1-InstanceId}} is SSH-reachable from the internet"
+type = "binary"
+
+[[criterion]]
+name = "no_other_instances_besides_ec2_multiregion_ec2_k"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): No other instances besides {{ec2-multiregion-EC2-ks84v1fh12-us-east-1-LaunchTemplateInstanceId}} and {{ec2-multiregion-EC2-ks84v1fh12-us-east-1-InstanceId}} are SSH-reachable from the internet"
+type = "binary"
+
+[[criterion]]
+name = "no_extraneous_or_contradicting_facts"
+description = "Per the rubric's Fail-If and Clarifications rules, does the junior engineer's answer AVOID both of the following: (1) stating any fact that contradicts the reference answer's stated infrastructure state (e.g. a different count, the wrong resource, an opposite status), and (2) claiming the existence of additional resources, findings, or facts beyond what the reference answer states, in a way that would mislead a practitioner into a different conclusion or action. Judge the junior's answer as a whole against the entire reference answer for this, not any single claim. Answer 'yes' if the junior's answer contains no such contradiction or unsupported extra claim; answer 'no' if it does."
 type = "binary"

--- a/tasks/ec2-multiregion/list-ec-instances-all-regions-1/tests/judge_prompt.md
+++ b/tasks/ec2-multiregion/list-ec-instances-all-regions-1/tests/judge_prompt.md
@@ -7,25 +7,27 @@ You will be shown two files in the user message:
    - `instruction`: the task itself (what the user asked).
    - `expected_answer`: the senior engineer's reference answer.
 
-## Evaluation Standard
+## General Guidance
+
+### Evaluation Standard
 
 The answers are EQUIVALENT if a practitioner following the junior's answer would reach the same conclusion and take the same effective action as someone following the senior's answer.
 
-## Must Match
+### Must Match
 
 - The primary root cause or diagnosis.
 - The overall verdict (broken/working, how many, which resource).
 - All distinct root causes if the senior identifies multiple.
 - If a fix is proposed: it must actually work. A command missing required parameters or targeting the wrong resource is NOT equivalent, even if the diagnosis is correct.
 
-## May Differ
+### May Differ
 
 - Wording, formatting, level of detail, or method of investigation.
 - Console URLs, dashboard links, retention periods, region names when obvious.
 - Additional correct information beyond the reference.
 - Formatting details of identifiers when the resource is unambiguously identified.
 
-## Fail If
+### Fail If
 
 1. Wrong verdict (broken vs working).
 2. Wrong root cause that would not explain or fix the problem.
@@ -34,19 +36,27 @@ The answers are EQUIVALENT if a practitioner following the junior's answer would
 5. Missing a primary root cause the senior identified.
 6. Introduces false claims about the infrastructure that would mislead a practitioner. Minor imprecisions in non-actionable details do not count.
 
-## Clarifications
+### Clarifications
 
 - Omitting a detail is acceptable UNLESS it changes what action a practitioner would take.
 - Merely mentioning an approach is not the same as providing it as the solution.
 - Listing more resources than the reference says exist is NOT equivalent.
 - If the junior answers with a question and the senior gives an explicit answer, NOT equivalent.
 
-## Steps
+### Steps
 
 1. Read the instruction to understand what was asked.
 2. Identify what action a practitioner would take from the senior's answer.
 3. Check if the junior's answer leads to the same effective action.
 4. Check if any Fail condition applies.
 5. If same effective action and no fail condition: EQUIVALENT.
+
+## Per-Claim Grading
+
+This task's reference answer has been decomposed into the individual claims listed below. Score each claim independently, on its own merits -- whether the junior's answer covers other listed claims should not affect this one.
+
+- For each claim, judge whether the junior's answer in agent-output.txt supports it, allowing for differences in wording, formatting, or level of detail per the Must Match / May Differ / Fail If rules above.
+- A claim about a fix or remediation step is satisfied when the junior proposes an equivalent fix; a claim about a root cause is satisfied when the junior identifies an equivalent cause.
+- EXCEPTION: the claim named `no_extraneous_or_contradicting_facts` (if listed below) is judged differently from every other claim here -- follow its own description, which judges the answer as a WHOLE against the ENTIRE reference answer, not one isolated fact.
 
 {criteria}

--- a/tasks/ec2-multiregion/list-ec-instances-all-regions-1/tests/resolve_placeholders.py
+++ b/tasks/ec2-multiregion/list-ec-instances-all-regions-1/tests/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/tasks/ec2-multiregion/list-ec-instances-all-regions-1/tests/resolve_placeholders.py
+++ b/tasks/ec2-multiregion/list-ec-instances-all-regions-1/tests/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:

--- a/tasks/ec2-multiregion/list-ec-instances-all-regions/tests/judge.toml
+++ b/tasks/ec2-multiregion/list-ec-instances-all-regions/tests/judge.toml
@@ -5,9 +5,39 @@ files = [
     "/tests/ground_truth.json",
 ]
 prompt_template = "judge_prompt.md"
-mode = "individual"
+mode = "batched"
 
 [[criterion]]
-name = "answers_equivalent"
-description = "Are the junior engineer's findings equivalent to the senior engineer's reference answer per the rubric?"
+name = "in_us_east_1_region_you_have_the_ec2_instance_ec"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): In us-east-1 region you have the EC2 instance {{ec2-multiregion-EC2-ks84v1fh12-us-east-1-InstanceId}}"
+type = "binary"
+
+[[criterion]]
+name = "in_us_east_1_region_you_have_the_ec2_instance_ec_2"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): In us-east-1 region you have the EC2 instance {{ec2-multiregion-EC2-ks84v1fh12-us-east-1-LaunchTemplateInstanceId}}"
+type = "binary"
+
+[[criterion]]
+name = "in_us_east_1_region_you_have_the_ec2_instance_ec_3"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): In us-east-1 region you have the EC2 instance {{ec2-multiregion-EC2-ks84v1fh12-us-east-1-DefaultVPCInstanceId}}"
+type = "binary"
+
+[[criterion]]
+name = "in_us_east_1_region_you_have_the_ec2_instance_ec_4"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): In us-east-1 region you have the EC2 instance {{ec2-multiregion-EC2-ks84v1fh12-us-east-1-PrivateInstanceId}}"
+type = "binary"
+
+[[criterion]]
+name = "in_us_west_1_region_you_have_the_ec2_instance_ec"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): In us-west-1 region you have the EC2 instance {{ec2-multiregion-EC2-ls9fuhb522-us-west-1-InstanceId}}"
+type = "binary"
+
+[[criterion]]
+name = "in_us_west_2_region_you_have_the_ec2_instance_ec"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): In us-west-2 region you have the EC2 instance {{ec2-multiregion-EC2-ls9fuhb522-us-west-2-InstanceId}}"
+type = "binary"
+
+[[criterion]]
+name = "no_extraneous_or_contradicting_facts"
+description = "Per the rubric's Fail-If and Clarifications rules, does the junior engineer's answer AVOID both of the following: (1) stating any fact that contradicts the reference answer's stated infrastructure state (e.g. a different count, the wrong resource, an opposite status), and (2) claiming the existence of additional resources, findings, or facts beyond what the reference answer states, in a way that would mislead a practitioner into a different conclusion or action. Judge the junior's answer as a whole against the entire reference answer for this, not any single claim. Answer 'yes' if the junior's answer contains no such contradiction or unsupported extra claim; answer 'no' if it does. IMPORTANT: this account is restricted by an SCP to only us-east-1, us-west-1, and us-west-2 -- the reference answer's own instance counts were derived by attempting every AWS region and discarding the ones that raised AccessDenied. If the junior's answer notes that it attempted other regions and was denied access (e.g. by an SCP, or an AccessDenied/UnauthorizedOperation error), that is NOT an extraneous or contradicting claim -- it is the same methodology the reference answer used, and must not cause this criterion to fail."
 type = "binary"

--- a/tasks/ec2-multiregion/list-ec-instances-all-regions/tests/judge_prompt.md
+++ b/tasks/ec2-multiregion/list-ec-instances-all-regions/tests/judge_prompt.md
@@ -7,25 +7,27 @@ You will be shown two files in the user message:
    - `instruction`: the task itself (what the user asked).
    - `expected_answer`: the senior engineer's reference answer.
 
-## Evaluation Standard
+## General Guidance
+
+### Evaluation Standard
 
 The answers are EQUIVALENT if a practitioner following the junior's answer would reach the same conclusion and take the same effective action as someone following the senior's answer.
 
-## Must Match
+### Must Match
 
 - The primary root cause or diagnosis.
 - The overall verdict (broken/working, how many, which resource).
 - All distinct root causes if the senior identifies multiple.
 - If a fix is proposed: it must actually work. A command missing required parameters or targeting the wrong resource is NOT equivalent, even if the diagnosis is correct.
 
-## May Differ
+### May Differ
 
 - Wording, formatting, level of detail, or method of investigation.
 - Console URLs, dashboard links, retention periods, region names when obvious.
 - Additional correct information beyond the reference.
 - Formatting details of identifiers when the resource is unambiguously identified.
 
-## Fail If
+### Fail If
 
 1. Wrong verdict (broken vs working).
 2. Wrong root cause that would not explain or fix the problem.
@@ -34,19 +36,27 @@ The answers are EQUIVALENT if a practitioner following the junior's answer would
 5. Missing a primary root cause the senior identified.
 6. Introduces false claims about the infrastructure that would mislead a practitioner. Minor imprecisions in non-actionable details do not count.
 
-## Clarifications
+### Clarifications
 
 - Omitting a detail is acceptable UNLESS it changes what action a practitioner would take.
 - Merely mentioning an approach is not the same as providing it as the solution.
 - Listing more resources than the reference says exist is NOT equivalent.
 - If the junior answers with a question and the senior gives an explicit answer, NOT equivalent.
 
-## Steps
+### Steps
 
 1. Read the instruction to understand what was asked.
 2. Identify what action a practitioner would take from the senior's answer.
 3. Check if the junior's answer leads to the same effective action.
 4. Check if any Fail condition applies.
 5. If same effective action and no fail condition: EQUIVALENT.
+
+## Per-Claim Grading
+
+This task's reference answer has been decomposed into the individual claims listed below. Score each claim independently, on its own merits -- whether the junior's answer covers other listed claims should not affect this one.
+
+- For each claim, judge whether the junior's answer in agent-output.txt supports it, allowing for differences in wording, formatting, or level of detail per the Must Match / May Differ / Fail If rules above.
+- A claim about a fix or remediation step is satisfied when the junior proposes an equivalent fix; a claim about a root cause is satisfied when the junior identifies an equivalent cause.
+- EXCEPTION: the claim named `no_extraneous_or_contradicting_facts` (if listed below) is judged differently from every other claim here -- follow its own description, which judges the answer as a WHOLE against the ENTIRE reference answer, not one isolated fact.
 
 {criteria}

--- a/tasks/ec2-multiregion/list-ec-instances-all-regions/tests/resolve_placeholders.py
+++ b/tasks/ec2-multiregion/list-ec-instances-all-regions/tests/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/tasks/ec2-multiregion/list-ec-instances-all-regions/tests/resolve_placeholders.py
+++ b/tasks/ec2-multiregion/list-ec-instances-all-regions/tests/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:

--- a/tasks/ec2-multiregion/list-ec-instances-by-vpc-across-regions/tests/judge.toml
+++ b/tasks/ec2-multiregion/list-ec-instances-by-vpc-across-regions/tests/judge.toml
@@ -5,9 +5,39 @@ files = [
     "/tests/ground_truth.json",
 ]
 prompt_template = "judge_prompt.md"
-mode = "individual"
+mode = "batched"
 
 [[criterion]]
-name = "answers_equivalent"
-description = "Are the junior engineer's findings equivalent to the senior engineer's reference answer per the rubric?"
+name = "instance_ec2_multiregion_ec2_ks84v1fh12_us_east_"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): Instance {{ec2-multiregion-EC2-ks84v1fh12-us-east-1-InstanceId}} is in VPC {{ec2-multiregion-EC2-ks84v1fh12-us-east-1-VpcId}} in region us-east-1"
+type = "binary"
+
+[[criterion]]
+name = "instance_ec2_multiregion_ec2_ks84v1fh12_us_east__2"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): Instance {{ec2-multiregion-EC2-ks84v1fh12-us-east-1-LaunchTemplateInstanceId}} is in VPC {{ec2-multiregion-EC2-ks84v1fh12-us-east-1-VpcId}} in region us-east-1"
+type = "binary"
+
+[[criterion]]
+name = "instance_ec2_multiregion_ec2_ks84v1fh12_us_east__3"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): Instance {{ec2-multiregion-EC2-ks84v1fh12-us-east-1-PrivateInstanceId}} is in VPC {{ec2-multiregion-EC2-ks84v1fh12-us-east-1-VpcId}} in region us-east-1"
+type = "binary"
+
+[[criterion]]
+name = "instance_ec2_multiregion_ec2_ks84v1fh12_us_east__4"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): Instance {{ec2-multiregion-EC2-ks84v1fh12-us-east-1-DefaultVPCInstanceId}} is in VPC {{ec2-multiregion-EC2-ks84v1fh12-us-east-1-DefaultVpcId}} in region us-east-1"
+type = "binary"
+
+[[criterion]]
+name = "instance_ec2_multiregion_ec2_ls9fuhb522_us_west_"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): Instance {{ec2-multiregion-EC2-ls9fuhb522-us-west-1-InstanceId}} is in VPC {{ec2-multiregion-EC2-ls9fuhb522-us-west-1-VpcId}} in region us-west-1"
+type = "binary"
+
+[[criterion]]
+name = "instance_ec2_multiregion_ec2_ls9fuhb522_us_west__2"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): Instance {{ec2-multiregion-EC2-ls9fuhb522-us-west-2-InstanceId}} is in VPC {{ec2-multiregion-EC2-ls9fuhb522-us-west-2-VpcId}} in region us-west-2"
+type = "binary"
+
+[[criterion]]
+name = "no_extraneous_or_contradicting_facts"
+description = "Per the rubric's Fail-If and Clarifications rules, does the junior engineer's answer AVOID both of the following: (1) stating any fact that contradicts the reference answer's stated infrastructure state (e.g. a different count, the wrong resource, an opposite status), and (2) claiming the existence of additional resources, findings, or facts beyond what the reference answer states, in a way that would mislead a practitioner into a different conclusion or action. Judge the junior's answer as a whole against the entire reference answer for this, not any single claim. Answer 'yes' if the junior's answer contains no such contradiction or unsupported extra claim; answer 'no' if it does."
 type = "binary"

--- a/tasks/ec2-multiregion/list-ec-instances-by-vpc-across-regions/tests/judge_prompt.md
+++ b/tasks/ec2-multiregion/list-ec-instances-by-vpc-across-regions/tests/judge_prompt.md
@@ -7,25 +7,27 @@ You will be shown two files in the user message:
    - `instruction`: the task itself (what the user asked).
    - `expected_answer`: the senior engineer's reference answer.
 
-## Evaluation Standard
+## General Guidance
+
+### Evaluation Standard
 
 The answers are EQUIVALENT if a practitioner following the junior's answer would reach the same conclusion and take the same effective action as someone following the senior's answer.
 
-## Must Match
+### Must Match
 
 - The primary root cause or diagnosis.
 - The overall verdict (broken/working, how many, which resource).
 - All distinct root causes if the senior identifies multiple.
 - If a fix is proposed: it must actually work. A command missing required parameters or targeting the wrong resource is NOT equivalent, even if the diagnosis is correct.
 
-## May Differ
+### May Differ
 
 - Wording, formatting, level of detail, or method of investigation.
 - Console URLs, dashboard links, retention periods, region names when obvious.
 - Additional correct information beyond the reference.
 - Formatting details of identifiers when the resource is unambiguously identified.
 
-## Fail If
+### Fail If
 
 1. Wrong verdict (broken vs working).
 2. Wrong root cause that would not explain or fix the problem.
@@ -34,19 +36,27 @@ The answers are EQUIVALENT if a practitioner following the junior's answer would
 5. Missing a primary root cause the senior identified.
 6. Introduces false claims about the infrastructure that would mislead a practitioner. Minor imprecisions in non-actionable details do not count.
 
-## Clarifications
+### Clarifications
 
 - Omitting a detail is acceptable UNLESS it changes what action a practitioner would take.
 - Merely mentioning an approach is not the same as providing it as the solution.
 - Listing more resources than the reference says exist is NOT equivalent.
 - If the junior answers with a question and the senior gives an explicit answer, NOT equivalent.
 
-## Steps
+### Steps
 
 1. Read the instruction to understand what was asked.
 2. Identify what action a practitioner would take from the senior's answer.
 3. Check if the junior's answer leads to the same effective action.
 4. Check if any Fail condition applies.
 5. If same effective action and no fail condition: EQUIVALENT.
+
+## Per-Claim Grading
+
+This task's reference answer has been decomposed into the individual claims listed below. Score each claim independently, on its own merits -- whether the junior's answer covers other listed claims should not affect this one.
+
+- For each claim, judge whether the junior's answer in agent-output.txt supports it, allowing for differences in wording, formatting, or level of detail per the Must Match / May Differ / Fail If rules above.
+- A claim about a fix or remediation step is satisfied when the junior proposes an equivalent fix; a claim about a root cause is satisfied when the junior identifies an equivalent cause.
+- EXCEPTION: the claim named `no_extraneous_or_contradicting_facts` (if listed below) is judged differently from every other claim here -- follow its own description, which judges the answer as a WHOLE against the ENTIRE reference answer, not one isolated fact.
 
 {criteria}

--- a/tasks/ec2-multiregion/list-ec-instances-by-vpc-across-regions/tests/resolve_placeholders.py
+++ b/tasks/ec2-multiregion/list-ec-instances-by-vpc-across-regions/tests/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/tasks/ec2-multiregion/list-ec-instances-by-vpc-across-regions/tests/resolve_placeholders.py
+++ b/tasks/ec2-multiregion/list-ec-instances-by-vpc-across-regions/tests/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:

--- a/tasks/ec2-multiregion/list-ec-private-ips-all-regions/tests/judge.toml
+++ b/tasks/ec2-multiregion/list-ec-private-ips-all-regions/tests/judge.toml
@@ -5,9 +5,39 @@ files = [
     "/tests/ground_truth.json",
 ]
 prompt_template = "judge_prompt.md"
-mode = "individual"
+mode = "batched"
 
 [[criterion]]
-name = "answers_equivalent"
-description = "Are the junior engineer's findings equivalent to the senior engineer's reference answer per the rubric?"
+name = "in_us_east_1_there_is_an_ec2_instance_ec2_multir"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): In us-east-1, there is an EC2 instance {{ec2-multiregion-EC2-ks84v1fh12-us-east-1-InstanceId}} with private IP {{ec2-multiregion-EC2-ks84v1fh12-us-east-1-PrivateIPOfInstanceWithoutLaunchTemplate}}"
+type = "binary"
+
+[[criterion]]
+name = "in_us_east_1_there_is_an_ec2_instance_ec2_multir_2"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): In us-east-1, there is an EC2 instance {{ec2-multiregion-EC2-ks84v1fh12-us-east-1-LaunchTemplateInstanceId}} with private IP {{ec2-multiregion-EC2-ks84v1fh12-us-east-1-PrivateIPOfInstanceWithLaunchTemplate}}"
+type = "binary"
+
+[[criterion]]
+name = "in_us_east_1_there_is_an_ec2_instance_ec2_multir_3"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): In us-east-1, there is an EC2 instance {{ec2-multiregion-EC2-ks84v1fh12-us-east-1-DefaultVPCInstanceId}} with private IP {{ec2-multiregion-EC2-ks84v1fh12-us-east-1-PrivateIPOfInstanceWithDefaultVpc}}"
+type = "binary"
+
+[[criterion]]
+name = "in_us_east_1_there_is_an_ec2_instance_ec2_multir_4"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): In us-east-1, there is an EC2 instance {{ec2-multiregion-EC2-ks84v1fh12-us-east-1-PrivateInstanceId}} with private IP {{ec2-multiregion-EC2-ks84v1fh12-us-east-1-PrivateInstancePrivateIp}}"
+type = "binary"
+
+[[criterion]]
+name = "in_us_west_1_there_is_an_ec2_instance_ec2_multir"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): In us-west-1, there is an EC2 instance {{ec2-multiregion-EC2-ls9fuhb522-us-west-1-InstanceId}} with private IP {{ec2-multiregion-EC2-ls9fuhb522-us-west-1-PrivateIPOfInstance}}"
+type = "binary"
+
+[[criterion]]
+name = "in_us_west_2_there_is_an_ec2_instance_ec2_multir"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): In us-west-2, there is an EC2 instance {{ec2-multiregion-EC2-ls9fuhb522-us-west-2-InstanceId}} with private IP {{ec2-multiregion-EC2-ls9fuhb522-us-west-2-PrivateIPOfInstance}}"
+type = "binary"
+
+[[criterion]]
+name = "no_extraneous_or_contradicting_facts"
+description = "Per the rubric's Fail-If and Clarifications rules, does the junior engineer's answer AVOID both of the following: (1) stating any fact that contradicts the reference answer's stated infrastructure state (e.g. a different count, the wrong resource, an opposite status), and (2) claiming the existence of additional resources, findings, or facts beyond what the reference answer states, in a way that would mislead a practitioner into a different conclusion or action. Judge the junior's answer as a whole against the entire reference answer for this, not any single claim. Answer 'yes' if the junior's answer contains no such contradiction or unsupported extra claim; answer 'no' if it does."
 type = "binary"

--- a/tasks/ec2-multiregion/list-ec-private-ips-all-regions/tests/judge_prompt.md
+++ b/tasks/ec2-multiregion/list-ec-private-ips-all-regions/tests/judge_prompt.md
@@ -7,25 +7,27 @@ You will be shown two files in the user message:
    - `instruction`: the task itself (what the user asked).
    - `expected_answer`: the senior engineer's reference answer.
 
-## Evaluation Standard
+## General Guidance
+
+### Evaluation Standard
 
 The answers are EQUIVALENT if a practitioner following the junior's answer would reach the same conclusion and take the same effective action as someone following the senior's answer.
 
-## Must Match
+### Must Match
 
 - The primary root cause or diagnosis.
 - The overall verdict (broken/working, how many, which resource).
 - All distinct root causes if the senior identifies multiple.
 - If a fix is proposed: it must actually work. A command missing required parameters or targeting the wrong resource is NOT equivalent, even if the diagnosis is correct.
 
-## May Differ
+### May Differ
 
 - Wording, formatting, level of detail, or method of investigation.
 - Console URLs, dashboard links, retention periods, region names when obvious.
 - Additional correct information beyond the reference.
 - Formatting details of identifiers when the resource is unambiguously identified.
 
-## Fail If
+### Fail If
 
 1. Wrong verdict (broken vs working).
 2. Wrong root cause that would not explain or fix the problem.
@@ -34,19 +36,27 @@ The answers are EQUIVALENT if a practitioner following the junior's answer would
 5. Missing a primary root cause the senior identified.
 6. Introduces false claims about the infrastructure that would mislead a practitioner. Minor imprecisions in non-actionable details do not count.
 
-## Clarifications
+### Clarifications
 
 - Omitting a detail is acceptable UNLESS it changes what action a practitioner would take.
 - Merely mentioning an approach is not the same as providing it as the solution.
 - Listing more resources than the reference says exist is NOT equivalent.
 - If the junior answers with a question and the senior gives an explicit answer, NOT equivalent.
 
-## Steps
+### Steps
 
 1. Read the instruction to understand what was asked.
 2. Identify what action a practitioner would take from the senior's answer.
 3. Check if the junior's answer leads to the same effective action.
 4. Check if any Fail condition applies.
 5. If same effective action and no fail condition: EQUIVALENT.
+
+## Per-Claim Grading
+
+This task's reference answer has been decomposed into the individual claims listed below. Score each claim independently, on its own merits -- whether the junior's answer covers other listed claims should not affect this one.
+
+- For each claim, judge whether the junior's answer in agent-output.txt supports it, allowing for differences in wording, formatting, or level of detail per the Must Match / May Differ / Fail If rules above.
+- A claim about a fix or remediation step is satisfied when the junior proposes an equivalent fix; a claim about a root cause is satisfied when the junior identifies an equivalent cause.
+- EXCEPTION: the claim named `no_extraneous_or_contradicting_facts` (if listed below) is judged differently from every other claim here -- follow its own description, which judges the answer as a WHOLE against the ENTIRE reference answer, not one isolated fact.
 
 {criteria}

--- a/tasks/ec2-multiregion/list-ec-private-ips-all-regions/tests/resolve_placeholders.py
+++ b/tasks/ec2-multiregion/list-ec-private-ips-all-regions/tests/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/tasks/ec2-multiregion/list-ec-private-ips-all-regions/tests/resolve_placeholders.py
+++ b/tasks/ec2-multiregion/list-ec-private-ips-all-regions/tests/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:

--- a/tasks/ec2-multiregion/list-unused-security-groups-all-regions/tests/judge.toml
+++ b/tasks/ec2-multiregion/list-unused-security-groups-all-regions/tests/judge.toml
@@ -5,9 +5,24 @@ files = [
     "/tests/ground_truth.json",
 ]
 prompt_template = "judge_prompt.md"
-mode = "individual"
+mode = "batched"
 
 [[criterion]]
-name = "answers_equivalent"
-description = "Are the junior engineer's findings equivalent to the senior engineer's reference answer per the rubric?"
+name = "you_have_4b68864e_unusedsecuritygroupcount_unuse"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): You have {{4b68864e-UnusedSecurityGroupCount}} unused security groups"
+type = "binary"
+
+[[criterion]]
+name = "most_unused_security_groups_are_default_security"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): Most unused security groups are default security groups automatically created for each VPC"
+type = "binary"
+
+[[criterion]]
+name = "in_us_east_1_one_of_the_unused_security_groups_i"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): In us-east-1, one of the unused security groups is {{ec2-multiregion-EC2-ks84v1fh12-us-east-1-UnusedSecurityGroupId}}"
+type = "binary"
+
+[[criterion]]
+name = "no_extraneous_or_contradicting_facts"
+description = "Per the rubric's Fail-If and Clarifications rules, does the junior engineer's answer AVOID both of the following: (1) stating any fact that contradicts the reference answer's stated infrastructure state (e.g. a different count, the wrong resource, an opposite status), and (2) claiming the existence of additional resources, findings, or facts beyond what the reference answer states, in a way that would mislead a practitioner into a different conclusion or action. Judge the junior's answer as a whole against the entire reference answer for this, not any single claim. Answer 'yes' if the junior's answer contains no such contradiction or unsupported extra claim; answer 'no' if it does."
 type = "binary"

--- a/tasks/ec2-multiregion/list-unused-security-groups-all-regions/tests/judge_prompt.md
+++ b/tasks/ec2-multiregion/list-unused-security-groups-all-regions/tests/judge_prompt.md
@@ -7,25 +7,27 @@ You will be shown two files in the user message:
    - `instruction`: the task itself (what the user asked).
    - `expected_answer`: the senior engineer's reference answer.
 
-## Evaluation Standard
+## General Guidance
+
+### Evaluation Standard
 
 The answers are EQUIVALENT if a practitioner following the junior's answer would reach the same conclusion and take the same effective action as someone following the senior's answer.
 
-## Must Match
+### Must Match
 
 - The primary root cause or diagnosis.
 - The overall verdict (broken/working, how many, which resource).
 - All distinct root causes if the senior identifies multiple.
 - If a fix is proposed: it must actually work. A command missing required parameters or targeting the wrong resource is NOT equivalent, even if the diagnosis is correct.
 
-## May Differ
+### May Differ
 
 - Wording, formatting, level of detail, or method of investigation.
 - Console URLs, dashboard links, retention periods, region names when obvious.
 - Additional correct information beyond the reference.
 - Formatting details of identifiers when the resource is unambiguously identified.
 
-## Fail If
+### Fail If
 
 1. Wrong verdict (broken vs working).
 2. Wrong root cause that would not explain or fix the problem.
@@ -34,19 +36,27 @@ The answers are EQUIVALENT if a practitioner following the junior's answer would
 5. Missing a primary root cause the senior identified.
 6. Introduces false claims about the infrastructure that would mislead a practitioner. Minor imprecisions in non-actionable details do not count.
 
-## Clarifications
+### Clarifications
 
 - Omitting a detail is acceptable UNLESS it changes what action a practitioner would take.
 - Merely mentioning an approach is not the same as providing it as the solution.
 - Listing more resources than the reference says exist is NOT equivalent.
 - If the junior answers with a question and the senior gives an explicit answer, NOT equivalent.
 
-## Steps
+### Steps
 
 1. Read the instruction to understand what was asked.
 2. Identify what action a practitioner would take from the senior's answer.
 3. Check if the junior's answer leads to the same effective action.
 4. Check if any Fail condition applies.
 5. If same effective action and no fail condition: EQUIVALENT.
+
+## Per-Claim Grading
+
+This task's reference answer has been decomposed into the individual claims listed below. Score each claim independently, on its own merits -- whether the junior's answer covers other listed claims should not affect this one.
+
+- For each claim, judge whether the junior's answer in agent-output.txt supports it, allowing for differences in wording, formatting, or level of detail per the Must Match / May Differ / Fail If rules above.
+- A claim about a fix or remediation step is satisfied when the junior proposes an equivalent fix; a claim about a root cause is satisfied when the junior identifies an equivalent cause.
+- EXCEPTION: the claim named `no_extraneous_or_contradicting_facts` (if listed below) is judged differently from every other claim here -- follow its own description, which judges the answer as a WHOLE against the ENTIRE reference answer, not one isolated fact.
 
 {criteria}

--- a/tasks/ec2-multiregion/list-unused-security-groups-all-regions/tests/resolve_placeholders.py
+++ b/tasks/ec2-multiregion/list-unused-security-groups-all-regions/tests/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/tasks/ec2-multiregion/list-unused-security-groups-all-regions/tests/resolve_placeholders.py
+++ b/tasks/ec2-multiregion/list-unused-security-groups-all-regions/tests/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:

--- a/tasks/reference-architectures/analyze-stepfunctions-job-poller-loop/tests/resolve_placeholders.py
+++ b/tasks/reference-architectures/analyze-stepfunctions-job-poller-loop/tests/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/tasks/reference-architectures/analyze-stepfunctions-job-poller-loop/tests/resolve_placeholders.py
+++ b/tasks/reference-architectures/analyze-stepfunctions-job-poller-loop/tests/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:

--- a/tasks/reference-architectures/audit-cognito-account-recovery/tests/resolve_placeholders.py
+++ b/tasks/reference-architectures/audit-cognito-account-recovery/tests/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/tasks/reference-architectures/audit-cognito-account-recovery/tests/resolve_placeholders.py
+++ b/tasks/reference-architectures/audit-cognito-account-recovery/tests/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:

--- a/tasks/reference-architectures/diagnose-batch-job-no-logs/tests/resolve_placeholders.py
+++ b/tasks/reference-architectures/diagnose-batch-job-no-logs/tests/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/tasks/reference-architectures/diagnose-batch-job-no-logs/tests/resolve_placeholders.py
+++ b/tasks/reference-architectures/diagnose-batch-job-no-logs/tests/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:

--- a/tasks/reference-architectures/diagnose-glue-pipeline-not-running/tests/resolve_placeholders.py
+++ b/tasks/reference-architectures/diagnose-glue-pipeline-not-running/tests/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/tasks/reference-architectures/diagnose-glue-pipeline-not-running/tests/resolve_placeholders.py
+++ b/tasks/reference-architectures/diagnose-glue-pipeline-not-running/tests/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:

--- a/tasks/reference-architectures/diagnose-rabbitmq-consumer-failure/tests/resolve_placeholders.py
+++ b/tasks/reference-architectures/diagnose-rabbitmq-consumer-failure/tests/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/tasks/reference-architectures/diagnose-rabbitmq-consumer-failure/tests/resolve_placeholders.py
+++ b/tasks/reference-architectures/diagnose-rabbitmq-consumer-failure/tests/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:

--- a/tasks/reference-architectures/diagnose-rekognition-reupload-stale/tests/resolve_placeholders.py
+++ b/tasks/reference-architectures/diagnose-rekognition-reupload-stale/tests/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/tasks/reference-architectures/diagnose-rekognition-reupload-stale/tests/resolve_placeholders.py
+++ b/tasks/reference-architectures/diagnose-rekognition-reupload-stale/tests/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:

--- a/tasks/reference-architectures/diagnose-s3-event-notification-break/tests/resolve_placeholders.py
+++ b/tasks/reference-architectures/diagnose-s3-event-notification-break/tests/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/tasks/reference-architectures/diagnose-s3-event-notification-break/tests/resolve_placeholders.py
+++ b/tasks/reference-architectures/diagnose-s3-event-notification-break/tests/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:

--- a/tasks/reference-architectures/diagnose-sftp-alarm-not-firing/tests/resolve_placeholders.py
+++ b/tasks/reference-architectures/diagnose-sftp-alarm-not-firing/tests/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/tasks/reference-architectures/diagnose-sftp-alarm-not-firing/tests/resolve_placeholders.py
+++ b/tasks/reference-architectures/diagnose-sftp-alarm-not-firing/tests/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:

--- a/tasks/reference-architectures/review-aurora-production-readiness/tests/resolve_placeholders.py
+++ b/tasks/reference-architectures/review-aurora-production-readiness/tests/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/tasks/reference-architectures/review-aurora-production-readiness/tests/resolve_placeholders.py
+++ b/tasks/reference-architectures/review-aurora-production-readiness/tests/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:

--- a/tasks/reference-architectures/review-backup-plan-cross-region/tests/resolve_placeholders.py
+++ b/tasks/reference-architectures/review-backup-plan-cross-region/tests/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/tasks/reference-architectures/review-backup-plan-cross-region/tests/resolve_placeholders.py
+++ b/tasks/reference-architectures/review-backup-plan-cross-region/tests/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:

--- a/tasks/reference-architectures/trace-ec2-ssh-access-path/tests/resolve_placeholders.py
+++ b/tasks/reference-architectures/trace-ec2-ssh-access-path/tests/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/tasks/reference-architectures/trace-ec2-ssh-access-path/tests/resolve_placeholders.py
+++ b/tasks/reference-architectures/trace-ec2-ssh-access-path/tests/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:

--- a/tasks/serverless-apps/check-lambda-layers-s-code/tests/resolve_placeholders.py
+++ b/tasks/serverless-apps/check-lambda-layers-s-code/tests/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/tasks/serverless-apps/check-lambda-layers-s-code/tests/resolve_placeholders.py
+++ b/tasks/serverless-apps/check-lambda-layers-s-code/tests/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:

--- a/tasks/serverless-apps/check-s-buckets-public-access/tests/resolve_placeholders.py
+++ b/tasks/serverless-apps/check-s-buckets-public-access/tests/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/tasks/serverless-apps/check-s-buckets-public-access/tests/resolve_placeholders.py
+++ b/tasks/serverless-apps/check-s-buckets-public-access/tests/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:

--- a/tasks/serverless-apps/check-s-lifecycle-tag-filter-rules/tests/resolve_placeholders.py
+++ b/tasks/serverless-apps/check-s-lifecycle-tag-filter-rules/tests/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/tasks/serverless-apps/check-s-lifecycle-tag-filter-rules/tests/resolve_placeholders.py
+++ b/tasks/serverless-apps/check-s-lifecycle-tag-filter-rules/tests/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:

--- a/tasks/serverless-apps/ecs-services-custom-configurations-check/tests/resolve_placeholders.py
+++ b/tasks/serverless-apps/ecs-services-custom-configurations-check/tests/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/tasks/serverless-apps/ecs-services-custom-configurations-check/tests/resolve_placeholders.py
+++ b/tasks/serverless-apps/ecs-services-custom-configurations-check/tests/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:

--- a/tasks/serverless-apps/ecs-services-ecr-access-check/tests/resolve_placeholders.py
+++ b/tasks/serverless-apps/ecs-services-ecr-access-check/tests/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/tasks/serverless-apps/ecs-services-ecr-access-check/tests/resolve_placeholders.py
+++ b/tasks/serverless-apps/ecs-services-ecr-access-check/tests/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:

--- a/tasks/serverless-apps/find-lambda-functions-tagged-blueprint/tests/resolve_placeholders.py
+++ b/tasks/serverless-apps/find-lambda-functions-tagged-blueprint/tests/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/tasks/serverless-apps/find-lambda-functions-tagged-blueprint/tests/resolve_placeholders.py
+++ b/tasks/serverless-apps/find-lambda-functions-tagged-blueprint/tests/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:

--- a/tasks/serverless-apps/find-metric-streams-excluding-namespace/tests/resolve_placeholders.py
+++ b/tasks/serverless-apps/find-metric-streams-excluding-namespace/tests/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/tasks/serverless-apps/find-metric-streams-excluding-namespace/tests/resolve_placeholders.py
+++ b/tasks/serverless-apps/find-metric-streams-excluding-namespace/tests/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:

--- a/tasks/serverless-apps/find-sns-triggered-lambda-functions/tests/resolve_placeholders.py
+++ b/tasks/serverless-apps/find-sns-triggered-lambda-functions/tests/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/tasks/serverless-apps/find-sns-triggered-lambda-functions/tests/resolve_placeholders.py
+++ b/tasks/serverless-apps/find-sns-triggered-lambda-functions/tests/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:

--- a/tasks/serverless-apps/list-s-buckets-website-hosting/tests/resolve_placeholders.py
+++ b/tasks/serverless-apps/list-s-buckets-website-hosting/tests/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/tasks/serverless-apps/list-s-buckets-website-hosting/tests/resolve_placeholders.py
+++ b/tasks/serverless-apps/list-s-buckets-website-hosting/tests/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:

--- a/tasks/serverless-apps/list-s-buckets-with-metrics-tag-filters/tests/resolve_placeholders.py
+++ b/tasks/serverless-apps/list-s-buckets-with-metrics-tag-filters/tests/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/tasks/serverless-apps/list-s-buckets-with-metrics-tag-filters/tests/resolve_placeholders.py
+++ b/tasks/serverless-apps/list-s-buckets-with-metrics-tag-filters/tests/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:

--- a/tasks/serverless-apps/list-s-cross-account-analytics-exports/tests/resolve_placeholders.py
+++ b/tasks/serverless-apps/list-s-cross-account-analytics-exports/tests/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/tasks/serverless-apps/list-s-cross-account-analytics-exports/tests/resolve_placeholders.py
+++ b/tasks/serverless-apps/list-s-cross-account-analytics-exports/tests/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:

--- a/tasks/serverless-apps/list-s-inventory-configs-with-prefix/tests/resolve_placeholders.py
+++ b/tasks/serverless-apps/list-s-inventory-configs-with-prefix/tests/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/tasks/serverless-apps/list-s-inventory-configs-with-prefix/tests/resolve_placeholders.py
+++ b/tasks/serverless-apps/list-s-inventory-configs-with-prefix/tests/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:

--- a/tasks/serverless-apps/s-bucket-metrics-tag-filter-check/tests/resolve_placeholders.py
+++ b/tasks/serverless-apps/s-bucket-metrics-tag-filter-check/tests/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/tasks/serverless-apps/s-bucket-metrics-tag-filter-check/tests/resolve_placeholders.py
+++ b/tasks/serverless-apps/s-bucket-metrics-tag-filter-check/tests/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:

--- a/tasks/troubleshooting-multiservice/asg-instance-health-check-failure/tests/resolve_placeholders.py
+++ b/tasks/troubleshooting-multiservice/asg-instance-health-check-failure/tests/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/tasks/troubleshooting-multiservice/asg-instance-health-check-failure/tests/resolve_placeholders.py
+++ b/tasks/troubleshooting-multiservice/asg-instance-health-check-failure/tests/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:

--- a/tasks/troubleshooting-multiservice/asg-secondary-network-interface-attach-failure/tests/resolve_placeholders.py
+++ b/tasks/troubleshooting-multiservice/asg-secondary-network-interface-attach-failure/tests/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/tasks/troubleshooting-multiservice/asg-secondary-network-interface-attach-failure/tests/resolve_placeholders.py
+++ b/tasks/troubleshooting-multiservice/asg-secondary-network-interface-attach-failure/tests/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:

--- a/tasks/troubleshooting-multiservice/check-vpc-flow-log-destinations/tests/resolve_placeholders.py
+++ b/tasks/troubleshooting-multiservice/check-vpc-flow-log-destinations/tests/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/tasks/troubleshooting-multiservice/check-vpc-flow-log-destinations/tests/resolve_placeholders.py
+++ b/tasks/troubleshooting-multiservice/check-vpc-flow-log-destinations/tests/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:

--- a/tasks/troubleshooting-multiservice/diagnose-asg-instance-issues/tests/resolve_placeholders.py
+++ b/tasks/troubleshooting-multiservice/diagnose-asg-instance-issues/tests/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/tasks/troubleshooting-multiservice/diagnose-asg-instance-issues/tests/resolve_placeholders.py
+++ b/tasks/troubleshooting-multiservice/diagnose-asg-instance-issues/tests/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:

--- a/tasks/troubleshooting-multiservice/diagnose-auto-scaling-group-launch-failure/tests/resolve_placeholders.py
+++ b/tasks/troubleshooting-multiservice/diagnose-auto-scaling-group-launch-failure/tests/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/tasks/troubleshooting-multiservice/diagnose-auto-scaling-group-launch-failure/tests/resolve_placeholders.py
+++ b/tasks/troubleshooting-multiservice/diagnose-auto-scaling-group-launch-failure/tests/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:

--- a/tasks/troubleshooting-multiservice/diagnose-ecs-cluster-no-traffic/tests/resolve_placeholders.py
+++ b/tasks/troubleshooting-multiservice/diagnose-ecs-cluster-no-traffic/tests/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/tasks/troubleshooting-multiservice/diagnose-ecs-cluster-no-traffic/tests/resolve_placeholders.py
+++ b/tasks/troubleshooting-multiservice/diagnose-ecs-cluster-no-traffic/tests/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:

--- a/tasks/troubleshooting-multiservice/diagnose-ecs-service-no-running-tasks-1/tests/resolve_placeholders.py
+++ b/tasks/troubleshooting-multiservice/diagnose-ecs-service-no-running-tasks-1/tests/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/tasks/troubleshooting-multiservice/diagnose-ecs-service-no-running-tasks-1/tests/resolve_placeholders.py
+++ b/tasks/troubleshooting-multiservice/diagnose-ecs-service-no-running-tasks-1/tests/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:

--- a/tasks/troubleshooting-multiservice/diagnose-emr-cluster-performance-issues/tests/resolve_placeholders.py
+++ b/tasks/troubleshooting-multiservice/diagnose-emr-cluster-performance-issues/tests/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/tasks/troubleshooting-multiservice/diagnose-emr-cluster-performance-issues/tests/resolve_placeholders.py
+++ b/tasks/troubleshooting-multiservice/diagnose-emr-cluster-performance-issues/tests/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:

--- a/tasks/troubleshooting-multiservice/diagnose-redshift-cluster-health-issues/tests/resolve_placeholders.py
+++ b/tasks/troubleshooting-multiservice/diagnose-redshift-cluster-health-issues/tests/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/tasks/troubleshooting-multiservice/diagnose-redshift-cluster-health-issues/tests/resolve_placeholders.py
+++ b/tasks/troubleshooting-multiservice/diagnose-redshift-cluster-health-issues/tests/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:

--- a/tasks/troubleshooting-multiservice/diagnose-step-functions-failing-executions/tests/resolve_placeholders.py
+++ b/tasks/troubleshooting-multiservice/diagnose-step-functions-failing-executions/tests/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/tasks/troubleshooting-multiservice/diagnose-step-functions-failing-executions/tests/resolve_placeholders.py
+++ b/tasks/troubleshooting-multiservice/diagnose-step-functions-failing-executions/tests/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:

--- a/tasks/troubleshooting-multiservice/ec-instance-security-vulnerability-scan/tests/resolve_placeholders.py
+++ b/tasks/troubleshooting-multiservice/ec-instance-security-vulnerability-scan/tests/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/tasks/troubleshooting-multiservice/ec-instance-security-vulnerability-scan/tests/resolve_placeholders.py
+++ b/tasks/troubleshooting-multiservice/ec-instance-security-vulnerability-scan/tests/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:

--- a/tasks/troubleshooting-multiservice/ec-secrets-manager-exit-code-error/tests/resolve_placeholders.py
+++ b/tasks/troubleshooting-multiservice/ec-secrets-manager-exit-code-error/tests/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/tasks/troubleshooting-multiservice/ec-secrets-manager-exit-code-error/tests/resolve_placeholders.py
+++ b/tasks/troubleshooting-multiservice/ec-secrets-manager-exit-code-error/tests/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:

--- a/tasks/troubleshooting-multiservice/ecs-elasticache-transit-gateway-connectivity/tests/resolve_placeholders.py
+++ b/tasks/troubleshooting-multiservice/ecs-elasticache-transit-gateway-connectivity/tests/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/tasks/troubleshooting-multiservice/ecs-elasticache-transit-gateway-connectivity/tests/resolve_placeholders.py
+++ b/tasks/troubleshooting-multiservice/ecs-elasticache-transit-gateway-connectivity/tests/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:

--- a/tasks/troubleshooting-multiservice/ecs-service-deployment-failure-diagnosis/tests/resolve_placeholders.py
+++ b/tasks/troubleshooting-multiservice/ecs-service-deployment-failure-diagnosis/tests/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/tasks/troubleshooting-multiservice/ecs-service-deployment-failure-diagnosis/tests/resolve_placeholders.py
+++ b/tasks/troubleshooting-multiservice/ecs-service-deployment-failure-diagnosis/tests/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:

--- a/tasks/troubleshooting-multiservice/eventbridge-ecs-task-trigger-debugging/tests/resolve_placeholders.py
+++ b/tasks/troubleshooting-multiservice/eventbridge-ecs-task-trigger-debugging/tests/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/tasks/troubleshooting-multiservice/eventbridge-ecs-task-trigger-debugging/tests/resolve_placeholders.py
+++ b/tasks/troubleshooting-multiservice/eventbridge-ecs-task-trigger-debugging/tests/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:

--- a/tasks/troubleshooting-multiservice/fix-cloudformation-update-failed-stack/tests/resolve_placeholders.py
+++ b/tasks/troubleshooting-multiservice/fix-cloudformation-update-failed-stack/tests/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/tasks/troubleshooting-multiservice/fix-cloudformation-update-failed-stack/tests/resolve_placeholders.py
+++ b/tasks/troubleshooting-multiservice/fix-cloudformation-update-failed-stack/tests/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:

--- a/tasks/troubleshooting-multiservice/glue-job-wrong-deployment-region/tests/resolve_placeholders.py
+++ b/tasks/troubleshooting-multiservice/glue-job-wrong-deployment-region/tests/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/tasks/troubleshooting-multiservice/glue-job-wrong-deployment-region/tests/resolve_placeholders.py
+++ b/tasks/troubleshooting-multiservice/glue-job-wrong-deployment-region/tests/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:

--- a/tasks/troubleshooting-multiservice/lambda-appconfig-stale-value-troubleshoot/tests/resolve_placeholders.py
+++ b/tasks/troubleshooting-multiservice/lambda-appconfig-stale-value-troubleshoot/tests/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/tasks/troubleshooting-multiservice/lambda-appconfig-stale-value-troubleshoot/tests/resolve_placeholders.py
+++ b/tasks/troubleshooting-multiservice/lambda-appconfig-stale-value-troubleshoot/tests/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:

--- a/tasks/troubleshooting-multiservice/troubleshoot-asg-ssh-connectivity/tests/resolve_placeholders.py
+++ b/tasks/troubleshooting-multiservice/troubleshoot-asg-ssh-connectivity/tests/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/tasks/troubleshooting-multiservice/troubleshoot-asg-ssh-connectivity/tests/resolve_placeholders.py
+++ b/tasks/troubleshooting-multiservice/troubleshoot-asg-ssh-connectivity/tests/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:

--- a/tasks/troubleshooting-multiservice/troubleshoot-glue-job-table-read-failure/tests/resolve_placeholders.py
+++ b/tasks/troubleshooting-multiservice/troubleshoot-glue-job-table-read-failure/tests/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/tasks/troubleshooting-multiservice/troubleshoot-glue-job-table-read-failure/tests/resolve_placeholders.py
+++ b/tasks/troubleshooting-multiservice/troubleshoot-glue-job-table-read-failure/tests/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:

--- a/tasks/troubleshooting-multiservice/verify-ec-traffic-routes-through-network-firewall/tests/resolve_placeholders.py
+++ b/tasks/troubleshooting-multiservice/verify-ec-traffic-routes-through-network-firewall/tests/resolve_placeholders.py
@@ -1,47 +1,97 @@
-"""Resolve {{placeholder}} tokens in /tests/ground_truth.json in place.
+"""Resolve {{placeholder}} tokens in /tests/ground_truth.json and, if present,
+in /tests/judge.toml's [[criterion]].description fields, in place.
 
-The framework injects placeholder values from [verifier.env] in task.toml as
-env vars on the verifier container. This script reads ground_truth.json,
-substitutes {{name}} with the corresponding env var, and overwrites the file
-with the resolved version -- which rewardkit's judge.toml references as one
-of its [judge.files].
+rewardkit relays each criterion's description verbatim into the judge prompt
+with no substitution of its own, so a per-claim description embedding a raw
+{{name}} token would otherwise reach the judge unresolved. Line-based rather
+than a full TOML re-serialize, to preserve formatting/comments exactly.
 
-Strict: exits non-zero if any {{name}} isn't set, surfacing missing CFN
-exports loudly instead of silently leaking literal tokens to the judge.
-
-Skipped when /tests/ground_truth.json doesn't exist (some tasks, e.g.
-programmatic mutation verifiers, don't need it).
+Strict: exits non-zero if any {{name}} isn't set anywhere, surfacing missing
+CFN exports loudly instead of silently leaking literal tokens to the judge.
 """
 
-import json
 import os
 import re
 import sys
+import json
 
 GT = "/tests/ground_truth.json"
+JUDGE_TOML = "/tests/judge.toml"
+
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+DESCRIPTION_LINE_RE = re.compile(r'^(description\s*=\s*)"((?:[^"\\]|\\.)*)"(\s*)$')
+
+
+def _substitute(text: str, missing: list[str], escape=None) -> str:
+    """Replace every {{name}} in text with its env var value.
+
+    escape, when given, is applied to each replacement VALUE only (e.g. to
+    keep a value with a literal quote/backslash from breaking TOML string
+    syntax) -- never to the surrounding text, which may already contain its
+    own (correctly escaped) literal quotes/backslashes that must pass through
+    untouched.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        val = os.environ.get(key)
+        if val is None:
+            missing.append(key)
+            return match.group(0)
+        return escape(val) if escape else val
+
+    return PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _resolved_ground_truth(missing: list[str]) -> dict | None:
+    """Return the resolved ground_truth dict, or None if the file doesn't exist."""
+    if not os.path.exists(GT):
+        return None
+    with open(GT) as f:
+        gt = json.load(f)
+    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+
+
+def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:
+    """Return the resolved judge.toml lines, or None if the file doesn't exist
+    or has no [[criterion]].description placeholders to resolve."""
+    if not os.path.exists(JUDGE_TOML):
+        return None
+
+    with open(JUDGE_TOML) as f:
+        lines = f.readlines()
+
+    changed = False
+    for i, line in enumerate(lines):
+        has_newline = line.endswith("\n")
+        stripped = line[:-1] if has_newline else line
+        m = DESCRIPTION_LINE_RE.match(stripped)
+        if not m or "{{" not in m.group(2):
+            continue
+        prefix, value, trailing = m.group(1), m.group(2), m.group(3)
+        new_value = _substitute(value, missing, escape=_toml_escape)
+        if new_value == value:
+            continue
+        lines[i] = f'{prefix}"{new_value}"{trailing}' + ("\n" if has_newline else "")
+        changed = True
+
+    return lines if changed else None
 
 
 def main() -> int:
-    if not os.path.exists(GT):
-        return 0
-
-    with open(GT) as f:
-        gt = json.load(f)
-
+    # Two passes, matching over both files: compute every resolution first
+    # (collecting all missing placeholders across ground_truth.json AND
+    # judge.toml), and only write anything if nothing was missing anywhere --
+    # a partial write on failure would leave one file resolved and the other
+    # not, for no benefit, since a non-zero exit here aborts test.sh before
+    # rewardkit ever runs either file.
     missing: list[str] = []
-
-    def sub(s: str) -> str:
-        def _replace(match: re.Match[str]) -> str:
-            key = match.group(1)
-            val = os.environ.get(key)
-            if val is None:
-                missing.append(key)
-                return match.group(0)
-            return val
-
-        return re.sub(r"\{\{([^}]+)\}\}", _replace, s)
-
-    resolved = {k: sub(v) if isinstance(v, str) else v for k, v in gt.items()}
+    resolved_gt = _resolved_ground_truth(missing)
+    resolved_judge_lines = _resolved_judge_toml_lines(missing)
 
     if missing:
         print(
@@ -52,12 +102,18 @@ def main() -> int:
         )
         return 1
 
-    # Atomic write: a partial write here would leave the ground_truth corrupt
-    # for the judge (and unrecoverable, since we no longer have the source).
-    tmp_path = GT + ".tmp"
-    with open(tmp_path, "w") as f:
-        json.dump(resolved, f)
-    os.replace(tmp_path, GT)
+    if resolved_gt is not None:
+        tmp_path = GT + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(resolved_gt, f)
+        os.replace(tmp_path, GT)
+
+    if resolved_judge_lines is not None:
+        tmp_path = JUDGE_TOML + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.writelines(resolved_judge_lines)
+        os.replace(tmp_path, JUDGE_TOML)
+
     return 0
 
 

--- a/tasks/troubleshooting-multiservice/verify-ec-traffic-routes-through-network-firewall/tests/resolve_placeholders.py
+++ b/tasks/troubleshooting-multiservice/verify-ec-traffic-routes-through-network-firewall/tests/resolve_placeholders.py
@@ -53,7 +53,9 @@ def _resolved_ground_truth(missing: list[str]) -> dict | None:
         return None
     with open(GT) as f:
         gt = json.load(f)
-    return {k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()}
+    return {
+        k: _substitute(v, missing) if isinstance(v, str) else v for k, v in gt.items()
+    }
 
 
 def _resolved_judge_toml_lines(missing: list[str]) -> list[str] | None:


### PR DESCRIPTION
Release(judge): per-claim grading rubrics for quickstart tasks

## Summary

Replaces the single holistic answers_equivalent judge criterion with per-claim LLM rubrics for all 9 quickstart tasks (`ec2-multiregion`).

Instead of asking one LLM call "is the junior's answer equivalent to the reference?", each task's reference answer is decomposed into its individual factual claims, and each claim is graded independently as its own binary criterion — plus one standing `no_extraneous_or_contradicting_facts` criterion that still judges the answer as a whole, to catch contradictions or fabricated scope that no single per-claim check would see. This gives an auditable, per-fact breakdown of why an answer passed or failed, instead of one opaque yes/no. The judge is implemented in a batched mode that sends all of a task's per-claim criteria to the judge in a single LLM call instead of one call per criterion, which does not increase the number of LLM judge calls.

## Files changed

**Scope: quickstart only (`tasks/ec2-multiregion/`, 9 tasks, 18 files)**

| File | Per task | Purpose | Change |
|---|---|---|---|
| `tests/judge.toml` | 9 | Judge configuration and grading criteria | Replaced the single holistic criterion with decomposed per-claim criteria plus an anti-hallucination catch-all; two criteria further refined after live-trial findings |
| `tests/judge_prompt.md` | 9 | Instructions given to the judge model | Reorganized into a general-guidance section and a per-claim-grading section; no change to the underlying grading rules |

**Scope: repo-wide (all 99 introspection tasks + 3 shared files, 102 files)**

| File | Count | Purpose | Change |
|---|---|---|---|
| `tests/resolve_placeholders.py` (per task) | 99 | Verifier script that substitutes placeholder tokens with real values before grading | Extended to also resolve placeholder tokens inside `judge.toml`'s criteria, not just the reference answer — previously any per-claim criterion embedding a placeholder would reach the judge unresolved. No-op for tasks still on the single holistic criterion (no placeholders to resolve there) |
| `shared/judge/resolve_placeholders.py` | 1 | Canonical source for the file above | Same fix, promoted to canonical so future tasks inherit it |
| `shared/judge/scripts/sync.sh` | 1 | Keeps every task's shared judge files in sync with the canonical copy; used in CI drift checks | Made customization-aware: a task whose `judge.toml` has been decomposed into per-claim criteria is now only synced/checked on `test.sh`/`resolve_placeholders.py`, never `judge.toml`/`judge_prompt.md`. Previously this check failed permanently on any customized task, and the default sync mode would have silently overwritten customized judge files back to holistic |
| `shared/judge/README.md` | 1 | Docs for the files above | Documents the customization-aware behavior |
## Testing

1. Offline regrade (6 agent runs, re-scored without re-running the agent)

Six previously-completed agent runs across 3 agent x model combinations (54 trials total — 9 tasks × 6 runs) were re-scored against the new per-claim rubric and compared to each trial's original saved judge score, without re-running the agent or any live AWS calls. This was repeated three times across the fix iterations, to separate genuine rubric improvements from ordinary LLM judge-call noise.

Agreement with the original judge is 96.3% (final pass, 52 of 54 trials). The 2 remaining disagreements were individually root-caused: one is the original judge itself scoring a correct answer incorrectly (confirmed by re-running the original judge twice more on the same trial).

2. Live end-to-end testing against a real AWS account

All 9 tasks were also run live and end-to-end — real agent, real disposable AWS scenario account, real judge model call — through the actual production grading path, not simulated. The final sweep produced 9 of 9 tasks at reward 1.0 with zero unresolved placeholder tokens in any criterion.

## Follow-ups

- Gradual rollout to other partitions. This PR is quickstart-only; the same approach should roll out to basic and beyond as separate, incremental PRs.