### PR TITLE
feat(judge): generate llm-only per-claim verifiers for aws-bench-basic

### DIFF
--- a/tasks/databases-and-storage/analyze-s-intelligent-tiering-configs/tests/judge.toml
+++ b/tasks/databases-and-storage/analyze-s-intelligent-tiering-configs/tests/judge.toml
@@ -5,9 +5,24 @@ files = [
     "/tests/ground_truth.json",
 ]
 prompt_template = "judge_prompt.md"
-mode = "individual"
+mode = "batched"
 
 [[criterion]]
-name = "answers_equivalent"
-description = "Are the junior engineer's findings equivalent to the senior engineer's reference answer per the rubric?"
+name = "you_have_two_s3_buckets_without_intelligent_tier"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): You have two S3 buckets without Intelligent-Tiering configurations currently in your account"
+type = "binary"
+
+[[criterion]]
+name = "one_s3_bucket_without_intelligent_tiering_config"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): One S3 bucket without Intelligent-Tiering configuration is named {{databases-and-storage-S3-18475e2fc-us-east-1-S3BucketWithoutIntelligentTieringConfigurations1}}"
+type = "binary"
+
+[[criterion]]
+name = "one_s3_bucket_without_intelligent_tiering_config_2"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): One S3 bucket without Intelligent-Tiering configuration is named {{databases-and-storage-S3-18475e2fc-us-east-1-S3BucketWithoutIntelligentTieringConfigurations2}}"
+type = "binary"
+
+[[criterion]]
+name = "no_extraneous_or_contradicting_facts"
+description = "Per the rubric's Fail-If and Clarifications rules, does the junior engineer's answer AVOID both of the following: (1) stating any fact that contradicts the reference answer's stated infrastructure state (e.g. a different count, the wrong resource, an opposite status), and (2) claiming the existence of additional resources, findings, or facts beyond what the reference answer states, in a way that would mislead a practitioner into a different conclusion or action. Judge the junior's answer as a whole against the entire reference answer for this, not any single claim. Answer 'yes' if the junior's answer contains no such contradiction or unsupported extra claim; answer 'no' if it does."
 type = "binary"

--- a/tasks/databases-and-storage/analyze-s-intelligent-tiering-configs/tests/judge_prompt.md
+++ b/tasks/databases-and-storage/analyze-s-intelligent-tiering-configs/tests/judge_prompt.md
@@ -7,25 +7,27 @@ You will be shown two files in the user message:
    - `instruction`: the task itself (what the user asked).
    - `expected_answer`: the senior engineer's reference answer.
 
-## Evaluation Standard
+## General Guidance
+
+### Evaluation Standard
 
 The answers are EQUIVALENT if a practitioner following the junior's answer would reach the same conclusion and take the same effective action as someone following the senior's answer.
 
-## Must Match
+### Must Match
 
 - The primary root cause or diagnosis.
 - The overall verdict (broken/working, how many, which resource).
 - All distinct root causes if the senior identifies multiple.
 - If a fix is proposed: it must actually work. A command missing required parameters or targeting the wrong resource is NOT equivalent, even if the diagnosis is correct.
 
-## May Differ
+### May Differ
 
 - Wording, formatting, level of detail, or method of investigation.
 - Console URLs, dashboard links, retention periods, region names when obvious.
 - Additional correct information beyond the reference.
 - Formatting details of identifiers when the resource is unambiguously identified.
 
-## Fail If
+### Fail If
 
 1. Wrong verdict (broken vs working).
 2. Wrong root cause that would not explain or fix the problem.
@@ -34,19 +36,27 @@ The answers are EQUIVALENT if a practitioner following the junior's answer would
 5. Missing a primary root cause the senior identified.
 6. Introduces false claims about the infrastructure that would mislead a practitioner. Minor imprecisions in non-actionable details do not count.
 
-## Clarifications
+### Clarifications
 
 - Omitting a detail is acceptable UNLESS it changes what action a practitioner would take.
 - Merely mentioning an approach is not the same as providing it as the solution.
 - Listing more resources than the reference says exist is NOT equivalent.
 - If the junior answers with a question and the senior gives an explicit answer, NOT equivalent.
 
-## Steps
+### Steps
 
 1. Read the instruction to understand what was asked.
 2. Identify what action a practitioner would take from the senior's answer.
 3. Check if the junior's answer leads to the same effective action.
 4. Check if any Fail condition applies.
 5. If same effective action and no fail condition: EQUIVALENT.
+
+## Per-Claim Grading
+
+This task's reference answer has been decomposed into the individual claims listed below. Score each claim independently, on its own merits -- whether the junior's answer covers other listed claims should not affect this one.
+
+- For each claim, judge whether the junior's answer in agent-output.txt supports it, allowing for differences in wording, formatting, or level of detail per the Must Match / May Differ / Fail If rules above.
+- A claim about a fix or remediation step is satisfied when the junior proposes an equivalent fix; a claim about a root cause is satisfied when the junior identifies an equivalent cause.
+- EXCEPTION: the claim named `no_extraneous_or_contradicting_facts` (if listed below) is judged differently from every other claim here -- follow its own description, which judges the answer as a WHOLE against the ENTIRE reference answer, not one isolated fact.
 
 {criteria}

--- a/tasks/databases-and-storage/check-codebuild-project-nodejs-version/tests/judge.toml
+++ b/tasks/databases-and-storage/check-codebuild-project-nodejs-version/tests/judge.toml
@@ -5,9 +5,14 @@ files = [
     "/tests/ground_truth.json",
 ]
 prompt_template = "judge_prompt.md"
-mode = "individual"
+mode = "batched"
 
 [[criterion]]
-name = "answers_equivalent"
-description = "Are the junior engineer's findings equivalent to the senior engineer's reference answer per the rubric?"
+name = "the_node_js_version_configured_for_the_codebuild"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The Node.js version configured for the CodeBuild project {{databases-and-storage-codebuild-g5etw5eu5-us-east-1-ProjectName}} is {{databases-and-storage-codebuild-g5etw5eu5-us-east-1-NodeVersion}}."
+type = "binary"
+
+[[criterion]]
+name = "no_extraneous_or_contradicting_facts"
+description = "Per the rubric's Fail-If and Clarifications rules, does the junior engineer's answer AVOID both of the following: (1) stating any fact that contradicts the reference answer's stated infrastructure state (e.g. a different count, the wrong resource, an opposite status), and (2) claiming the existence of additional resources, findings, or facts beyond what the reference answer states, in a way that would mislead a practitioner into a different conclusion or action. Judge the junior's answer as a whole against the entire reference answer for this, not any single claim. Answer 'yes' if the junior's answer contains no such contradiction or unsupported extra claim; answer 'no' if it does."
 type = "binary"

--- a/tasks/databases-and-storage/check-codebuild-project-nodejs-version/tests/judge_prompt.md
+++ b/tasks/databases-and-storage/check-codebuild-project-nodejs-version/tests/judge_prompt.md
@@ -7,25 +7,27 @@ You will be shown two files in the user message:
    - `instruction`: the task itself (what the user asked).
    - `expected_answer`: the senior engineer's reference answer.
 
-## Evaluation Standard
+## General Guidance
+
+### Evaluation Standard
 
 The answers are EQUIVALENT if a practitioner following the junior's answer would reach the same conclusion and take the same effective action as someone following the senior's answer.
 
-## Must Match
+### Must Match
 
 - The primary root cause or diagnosis.
 - The overall verdict (broken/working, how many, which resource).
 - All distinct root causes if the senior identifies multiple.
 - If a fix is proposed: it must actually work. A command missing required parameters or targeting the wrong resource is NOT equivalent, even if the diagnosis is correct.
 
-## May Differ
+### May Differ
 
 - Wording, formatting, level of detail, or method of investigation.
 - Console URLs, dashboard links, retention periods, region names when obvious.
 - Additional correct information beyond the reference.
 - Formatting details of identifiers when the resource is unambiguously identified.
 
-## Fail If
+### Fail If
 
 1. Wrong verdict (broken vs working).
 2. Wrong root cause that would not explain or fix the problem.
@@ -34,19 +36,27 @@ The answers are EQUIVALENT if a practitioner following the junior's answer would
 5. Missing a primary root cause the senior identified.
 6. Introduces false claims about the infrastructure that would mislead a practitioner. Minor imprecisions in non-actionable details do not count.
 
-## Clarifications
+### Clarifications
 
 - Omitting a detail is acceptable UNLESS it changes what action a practitioner would take.
 - Merely mentioning an approach is not the same as providing it as the solution.
 - Listing more resources than the reference says exist is NOT equivalent.
 - If the junior answers with a question and the senior gives an explicit answer, NOT equivalent.
 
-## Steps
+### Steps
 
 1. Read the instruction to understand what was asked.
 2. Identify what action a practitioner would take from the senior's answer.
 3. Check if the junior's answer leads to the same effective action.
 4. Check if any Fail condition applies.
 5. If same effective action and no fail condition: EQUIVALENT.
+
+## Per-Claim Grading
+
+This task's reference answer has been decomposed into the individual claims listed below. Score each claim independently, on its own merits -- whether the junior's answer covers other listed claims should not affect this one.
+
+- For each claim, judge whether the junior's answer in agent-output.txt supports it, allowing for differences in wording, formatting, or level of detail per the Must Match / May Differ / Fail If rules above.
+- A claim about a fix or remediation step is satisfied when the junior proposes an equivalent fix; a claim about a root cause is satisfied when the junior identifies an equivalent cause.
+- EXCEPTION: the claim named `no_extraneous_or_contradicting_facts` (if listed below) is judged differently from every other claim here -- follow its own description, which judges the answer as a WHOLE against the ENTIRE reference answer, not one isolated fact.
 
 {criteria}

--- a/tasks/databases-and-storage/check-s-bucket-access-profiles/tests/judge.toml
+++ b/tasks/databases-and-storage/check-s-bucket-access-profiles/tests/judge.toml
@@ -5,9 +5,49 @@ files = [
     "/tests/ground_truth.json",
 ]
 prompt_template = "judge_prompt.md"
-mode = "individual"
+mode = "batched"
 
 [[criterion]]
-name = "answers_equivalent"
-description = "Are the junior engineer's findings equivalent to the senior engineer's reference answer per the rubric?"
+name = "the_iam_user_databases_and_storage_s3_8hdgte56j_"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The IAM user {{databases-and-storage-s3-8hdgte56j-us-east-1-DevProfileUserName}} has read access to the bucket {{databases-and-storage-s3-8hdgte56j-us-east-1-BucketName}}"
+type = "binary"
+
+[[criterion]]
+name = "databases_and_storage_s3_8hdgte56j_us_east_1_dev"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): {{databases-and-storage-s3-8hdgte56j-us-east-1-DevProfileUserName}} has s3:GetObject permission on {{databases-and-storage-s3-8hdgte56j-us-east-1-BucketName}} via the bucket's resource policy"
+type = "binary"
+
+[[criterion]]
+name = "databases_and_storage_s3_8hdgte56j_us_east_1_dev_2"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): {{databases-and-storage-s3-8hdgte56j-us-east-1-DevProfileUserName}} has s3:ListBucket permission on {{databases-and-storage-s3-8hdgte56j-us-east-1-BucketName}} via the bucket's resource policy"
+type = "binary"
+
+[[criterion]]
+name = "the_user_databases_and_storage_s3_8hdgte56j_us_e"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The user {{databases-and-storage-s3-8hdgte56j-us-east-1-StagingProfileUserName}} does not have access to {{databases-and-storage-s3-8hdgte56j-us-east-1-BucketName}}"
+type = "binary"
+
+[[criterion]]
+name = "databases_and_storage_s3_8hdgte56j_us_east_1_sta"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): {{databases-and-storage-s3-8hdgte56j-us-east-1-StagingProfileUserName}} has no identity-based policies"
+type = "binary"
+
+[[criterion]]
+name = "databases_and_storage_s3_8hdgte56j_us_east_1_sta_2"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): {{databases-and-storage-s3-8hdgte56j-us-east-1-StagingProfileUserName}} is not referenced in the bucket policy of {{databases-and-storage-s3-8hdgte56j-us-east-1-BucketName}}"
+type = "binary"
+
+[[criterion]]
+name = "no_other_iam_users_in_the_account_have_access_to"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): No other IAM users in the account have access to {{databases-and-storage-s3-8hdgte56j-us-east-1-BucketName}}"
+type = "binary"
+
+[[criterion]]
+name = "the_bucket_databases_and_storage_s3_8hdgte56j_us"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The bucket {{databases-and-storage-s3-8hdgte56j-us-east-1-BucketName}} contains {{databases-and-storage-s3-8hdgte56j-us-east-1-Content}}"
+type = "binary"
+
+[[criterion]]
+name = "no_extraneous_or_contradicting_facts"
+description = "Per the rubric's Fail-If and Clarifications rules, does the junior engineer's answer AVOID both of the following: (1) stating any fact that contradicts the reference answer's stated infrastructure state (e.g. a different count, the wrong resource, an opposite status), and (2) claiming the existence of additional resources, findings, or facts beyond what the reference answer states, in a way that would mislead a practitioner into a different conclusion or action. Judge the junior's answer as a whole against the entire reference answer for this, not any single claim. Answer 'yes' if the junior's answer contains no such contradiction or unsupported extra claim; answer 'no' if it does."
 type = "binary"

--- a/tasks/databases-and-storage/check-s-bucket-access-profiles/tests/judge_prompt.md
+++ b/tasks/databases-and-storage/check-s-bucket-access-profiles/tests/judge_prompt.md
@@ -7,25 +7,27 @@ You will be shown two files in the user message:
    - `instruction`: the task itself (what the user asked).
    - `expected_answer`: the senior engineer's reference answer.
 
-## Evaluation Standard
+## General Guidance
+
+### Evaluation Standard
 
 The answers are EQUIVALENT if a practitioner following the junior's answer would reach the same conclusion and take the same effective action as someone following the senior's answer.
 
-## Must Match
+### Must Match
 
 - The primary root cause or diagnosis.
 - The overall verdict (broken/working, how many, which resource).
 - All distinct root causes if the senior identifies multiple.
 - If a fix is proposed: it must actually work. A command missing required parameters or targeting the wrong resource is NOT equivalent, even if the diagnosis is correct.
 
-## May Differ
+### May Differ
 
 - Wording, formatting, level of detail, or method of investigation.
 - Console URLs, dashboard links, retention periods, region names when obvious.
 - Additional correct information beyond the reference.
 - Formatting details of identifiers when the resource is unambiguously identified.
 
-## Fail If
+### Fail If
 
 1. Wrong verdict (broken vs working).
 2. Wrong root cause that would not explain or fix the problem.
@@ -34,19 +36,27 @@ The answers are EQUIVALENT if a practitioner following the junior's answer would
 5. Missing a primary root cause the senior identified.
 6. Introduces false claims about the infrastructure that would mislead a practitioner. Minor imprecisions in non-actionable details do not count.
 
-## Clarifications
+### Clarifications
 
 - Omitting a detail is acceptable UNLESS it changes what action a practitioner would take.
 - Merely mentioning an approach is not the same as providing it as the solution.
 - Listing more resources than the reference says exist is NOT equivalent.
 - If the junior answers with a question and the senior gives an explicit answer, NOT equivalent.
 
-## Steps
+### Steps
 
 1. Read the instruction to understand what was asked.
 2. Identify what action a practitioner would take from the senior's answer.
 3. Check if the junior's answer leads to the same effective action.
 4. Check if any Fail condition applies.
 5. If same effective action and no fail condition: EQUIVALENT.
+
+## Per-Claim Grading
+
+This task's reference answer has been decomposed into the individual claims listed below. Score each claim independently, on its own merits -- whether the junior's answer covers other listed claims should not affect this one.
+
+- For each claim, judge whether the junior's answer in agent-output.txt supports it, allowing for differences in wording, formatting, or level of detail per the Must Match / May Differ / Fail If rules above.
+- A claim about a fix or remediation step is satisfied when the junior proposes an equivalent fix; a claim about a root cause is satisfied when the junior identifies an equivalent cause.
+- EXCEPTION: the claim named `no_extraneous_or_contradicting_facts` (if listed below) is judged differently from every other claim here -- follow its own description, which judges the answer as a WHOLE against the ENTIRE reference answer, not one isolated fact.
 
 {criteria}

--- a/tasks/databases-and-storage/check-s-vector-bucket-indexes-exist/tests/judge.toml
+++ b/tasks/databases-and-storage/check-s-vector-bucket-indexes-exist/tests/judge.toml
@@ -5,9 +5,29 @@ files = [
     "/tests/ground_truth.json",
 ]
 prompt_template = "judge_prompt.md"
-mode = "individual"
+mode = "batched"
 
 [[criterion]]
-name = "answers_equivalent"
-description = "Are the junior engineer's findings equivalent to the senior engineer's reference answer per the rubric?"
+name = "the_first_index_databases_and_storage_s3_jayd5c4"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The first index {{databases-and-storage-s3-jayd5c428-us-east-1-FirstVectorIndex}} contains vectors"
+type = "binary"
+
+[[criterion]]
+name = "the_first_index_databases_and_storage_s3_jayd5c4_2"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The first index {{databases-and-storage-s3-jayd5c428-us-east-1-FirstVectorIndex}} contains 3 documents. The instruction only asks to check if vectors exist, not to state a document count or metadata -- credit this claim if the junior's answer confirms vectors exist in this index and does not contradict a count of 3, even if the junior never explicitly states the count."
+type = "binary"
+
+[[criterion]]
+name = "the_second_index_databases_and_storage_s3_jayd5c"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The second index {{databases-and-storage-s3-jayd5c428-us-east-1-SecondVectorIndex}} is empty"
+type = "binary"
+
+[[criterion]]
+name = "no_vectors_exist_in_databases_and_storage_s3_jay"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): No vectors exist in {{databases-and-storage-s3-jayd5c428-us-east-1-SecondVectorIndex}}"
+type = "binary"
+
+[[criterion]]
+name = "no_extraneous_or_contradicting_facts"
+description = "Per the rubric's Fail-If and Clarifications rules, does the junior engineer's answer AVOID both of the following: (1) stating any fact that contradicts the reference answer's stated infrastructure state (e.g. a different count, the wrong resource, an opposite status), and (2) claiming the existence of additional resources, findings, or facts beyond what the reference answer states, in a way that would mislead a practitioner into a different conclusion or action. Judge the junior's answer as a whole against the entire reference answer for this, not any single claim. Answer 'yes' if the junior's answer contains no such contradiction or unsupported extra claim; answer 'no' if it does."
 type = "binary"

--- a/tasks/databases-and-storage/check-s-vector-bucket-indexes-exist/tests/judge_prompt.md
+++ b/tasks/databases-and-storage/check-s-vector-bucket-indexes-exist/tests/judge_prompt.md
@@ -7,25 +7,27 @@ You will be shown two files in the user message:
    - `instruction`: the task itself (what the user asked).
    - `expected_answer`: the senior engineer's reference answer.
 
-## Evaluation Standard
+## General Guidance
+
+### Evaluation Standard
 
 The answers are EQUIVALENT if a practitioner following the junior's answer would reach the same conclusion and take the same effective action as someone following the senior's answer.
 
-## Must Match
+### Must Match
 
 - The primary root cause or diagnosis.
 - The overall verdict (broken/working, how many, which resource).
 - All distinct root causes if the senior identifies multiple.
 - If a fix is proposed: it must actually work. A command missing required parameters or targeting the wrong resource is NOT equivalent, even if the diagnosis is correct.
 
-## May Differ
+### May Differ
 
 - Wording, formatting, level of detail, or method of investigation.
 - Console URLs, dashboard links, retention periods, region names when obvious.
 - Additional correct information beyond the reference.
 - Formatting details of identifiers when the resource is unambiguously identified.
 
-## Fail If
+### Fail If
 
 1. Wrong verdict (broken vs working).
 2. Wrong root cause that would not explain or fix the problem.
@@ -34,19 +36,27 @@ The answers are EQUIVALENT if a practitioner following the junior's answer would
 5. Missing a primary root cause the senior identified.
 6. Introduces false claims about the infrastructure that would mislead a practitioner. Minor imprecisions in non-actionable details do not count.
 
-## Clarifications
+### Clarifications
 
 - Omitting a detail is acceptable UNLESS it changes what action a practitioner would take.
 - Merely mentioning an approach is not the same as providing it as the solution.
 - Listing more resources than the reference says exist is NOT equivalent.
 - If the junior answers with a question and the senior gives an explicit answer, NOT equivalent.
 
-## Steps
+### Steps
 
 1. Read the instruction to understand what was asked.
 2. Identify what action a practitioner would take from the senior's answer.
 3. Check if the junior's answer leads to the same effective action.
 4. Check if any Fail condition applies.
 5. If same effective action and no fail condition: EQUIVALENT.
+
+## Per-Claim Grading
+
+This task's reference answer has been decomposed into the individual claims listed below. Score each claim independently, on its own merits -- whether the junior's answer covers other listed claims should not affect this one.
+
+- For each claim, judge whether the junior's answer in agent-output.txt supports it, allowing for differences in wording, formatting, or level of detail per the Must Match / May Differ / Fail If rules above.
+- A claim about a fix or remediation step is satisfied when the junior proposes an equivalent fix; a claim about a root cause is satisfied when the junior identifies an equivalent cause.
+- EXCEPTION: the claim named `no_extraneous_or_contradicting_facts` (if listed below) is judged differently from every other claim here -- follow its own description, which judges the answer as a WHOLE against the ENTIRE reference answer, not one isolated fact.
 
 {criteria}

--- a/tasks/databases-and-storage/cloudformation-top-stacks-resource-breakdown/tests/judge.toml
+++ b/tasks/databases-and-storage/cloudformation-top-stacks-resource-breakdown/tests/judge.toml
@@ -5,9 +5,39 @@ files = [
     "/tests/ground_truth.json",
 ]
 prompt_template = "judge_prompt.md"
-mode = "individual"
+mode = "batched"
 
 [[criterion]]
-name = "answers_equivalent"
-description = "Are the junior engineer's findings equivalent to the senior engineer's reference answer per the rubric?"
+name = "the_stack_with_the_most_resources_is_4dd10da5_st"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The stack with the most resources is {{4dd10da5-Stack1Name}} with {{4dd10da5-Stack1Count}} resources"
+type = "binary"
+
+[[criterion]]
+name = "the_top_3_resource_types_in_4dd10da5_stack1name_"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The top 3 resource types in {{4dd10da5-Stack1Name}} are {{4dd10da5-Stack1TopTypes}}"
+type = "binary"
+
+[[criterion]]
+name = "the_stack_with_the_second_most_resources_is_4dd1"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The stack with the second most resources is {{4dd10da5-Stack2Name}} with {{4dd10da5-Stack2Count}} resources"
+type = "binary"
+
+[[criterion]]
+name = "the_top_3_resource_types_in_4dd10da5_stack2name_"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The top 3 resource types in {{4dd10da5-Stack2Name}} are {{4dd10da5-Stack2TopTypes}}"
+type = "binary"
+
+[[criterion]]
+name = "the_stack_with_the_third_most_resources_is_4dd10"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The stack with the third most resources is {{4dd10da5-Stack3Name}} with {{4dd10da5-Stack3Count}} resources"
+type = "binary"
+
+[[criterion]]
+name = "the_top_3_resource_types_in_4dd10da5_stack3name_"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The top 3 resource types in {{4dd10da5-Stack3Name}} are {{4dd10da5-Stack3TopTypes}}"
+type = "binary"
+
+[[criterion]]
+name = "no_extraneous_or_contradicting_facts"
+description = "Per the rubric's Fail-If and Clarifications rules, does the junior engineer's answer AVOID both of the following: (1) stating any fact that contradicts the reference answer's stated infrastructure state (e.g. a different count, the wrong resource, an opposite status), and (2) claiming the existence of additional resources, findings, or facts beyond what the reference answer states, in a way that would mislead a practitioner into a different conclusion or action. Judge the junior's answer as a whole against the entire reference answer for this, not any single claim. Answer 'yes' if the junior's answer contains no such contradiction or unsupported extra claim; answer 'no' if it does."
 type = "binary"

--- a/tasks/databases-and-storage/cloudformation-top-stacks-resource-breakdown/tests/judge_prompt.md
+++ b/tasks/databases-and-storage/cloudformation-top-stacks-resource-breakdown/tests/judge_prompt.md
@@ -7,25 +7,27 @@ You will be shown two files in the user message:
    - `instruction`: the task itself (what the user asked).
    - `expected_answer`: the senior engineer's reference answer.
 
-## Evaluation Standard
+## General Guidance
+
+### Evaluation Standard
 
 The answers are EQUIVALENT if a practitioner following the junior's answer would reach the same conclusion and take the same effective action as someone following the senior's answer.
 
-## Must Match
+### Must Match
 
 - The primary root cause or diagnosis.
 - The overall verdict (broken/working, how many, which resource).
 - All distinct root causes if the senior identifies multiple.
 - If a fix is proposed: it must actually work. A command missing required parameters or targeting the wrong resource is NOT equivalent, even if the diagnosis is correct.
 
-## May Differ
+### May Differ
 
 - Wording, formatting, level of detail, or method of investigation.
 - Console URLs, dashboard links, retention periods, region names when obvious.
 - Additional correct information beyond the reference.
 - Formatting details of identifiers when the resource is unambiguously identified.
 
-## Fail If
+### Fail If
 
 1. Wrong verdict (broken vs working).
 2. Wrong root cause that would not explain or fix the problem.
@@ -34,19 +36,27 @@ The answers are EQUIVALENT if a practitioner following the junior's answer would
 5. Missing a primary root cause the senior identified.
 6. Introduces false claims about the infrastructure that would mislead a practitioner. Minor imprecisions in non-actionable details do not count.
 
-## Clarifications
+### Clarifications
 
 - Omitting a detail is acceptable UNLESS it changes what action a practitioner would take.
 - Merely mentioning an approach is not the same as providing it as the solution.
 - Listing more resources than the reference says exist is NOT equivalent.
 - If the junior answers with a question and the senior gives an explicit answer, NOT equivalent.
 
-## Steps
+### Steps
 
 1. Read the instruction to understand what was asked.
 2. Identify what action a practitioner would take from the senior's answer.
 3. Check if the junior's answer leads to the same effective action.
 4. Check if any Fail condition applies.
 5. If same effective action and no fail condition: EQUIVALENT.
+
+## Per-Claim Grading
+
+This task's reference answer has been decomposed into the individual claims listed below. Score each claim independently, on its own merits -- whether the junior's answer covers other listed claims should not affect this one.
+
+- For each claim, judge whether the junior's answer in agent-output.txt supports it, allowing for differences in wording, formatting, or level of detail per the Must Match / May Differ / Fail If rules above.
+- A claim about a fix or remediation step is satisfied when the junior proposes an equivalent fix; a claim about a root cause is satisfied when the junior identifies an equivalent cause.
+- EXCEPTION: the claim named `no_extraneous_or_contradicting_facts` (if listed below) is judged differently from every other claim here -- follow its own description, which judges the answer as a WHOLE against the ENTIRE reference answer, not one isolated fact.
 
 {criteria}

--- a/tasks/databases-and-storage/compare-s-bucket-structure-sizes/tests/judge.toml
+++ b/tasks/databases-and-storage/compare-s-bucket-structure-sizes/tests/judge.toml
@@ -5,9 +5,29 @@ files = [
     "/tests/ground_truth.json",
 ]
 prompt_template = "judge_prompt.md"
-mode = "individual"
+mode = "batched"
 
 [[criterion]]
-name = "answers_equivalent"
-description = "Are the junior engineer's findings equivalent to the senior engineer's reference answer per the rubric?"
+name = "databases_and_storage_s3_3kmc99rnc_us_east_1_buc"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): {{databases-and-storage-s3-3kmc99rnc-us-east-1-Bucket1Name}} contains folder structure {{databases-and-storage-s3-3kmc99rnc-us-east-1-SubDirectory1Name}}"
+type = "binary"
+
+[[criterion]]
+name = "databases_and_storage_s3_3kmc99rnc_us_east_1_buc_2"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): {{databases-and-storage-s3-3kmc99rnc-us-east-1-Bucket2Name}} contains folder structure {{databases-and-storage-s3-3kmc99rnc-us-east-1-SubDirectory2Name}}"
+type = "binary"
+
+[[criterion]]
+name = "the_file_content_in_databases_and_storage_s3_3km"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The files in {{databases-and-storage-s3-3kmc99rnc-us-east-1-SubDirectory1Name}} and {{databases-and-storage-s3-3kmc99rnc-us-east-1-SubDirectory2Name}} are consistent with each other (matching name and size). The instruction only asks to compare structure and file sizes, not byte-level content -- do not require the junior to explicitly verify or state that file CONTENT is identical; matching file name and size (already covered by the size claim below) is sufficient evidence to satisfy this claim."
+type = "binary"
+
+[[criterion]]
+name = "the_file_size_in_both_databases_and_storage_s3_3"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The file size in both {{databases-and-storage-s3-3kmc99rnc-us-east-1-SubDirectory1Name}} and {{databases-and-storage-s3-3kmc99rnc-us-east-1-SubDirectory2Name}} is 14 bytes"
+type = "binary"
+
+[[criterion]]
+name = "no_extraneous_or_contradicting_facts"
+description = "Per the rubric's Fail-If and Clarifications rules, does the junior engineer's answer AVOID both of the following: (1) stating any fact that contradicts the reference answer's stated infrastructure state (e.g. a different count, the wrong resource, an opposite status), and (2) claiming the existence of additional resources, findings, or facts beyond what the reference answer states, in a way that would mislead a practitioner into a different conclusion or action. Judge the junior's answer as a whole against the entire reference answer for this, not any single claim. Answer 'yes' if the junior's answer contains no such contradiction or unsupported extra claim; answer 'no' if it does."
 type = "binary"

--- a/tasks/databases-and-storage/compare-s-bucket-structure-sizes/tests/judge_prompt.md
+++ b/tasks/databases-and-storage/compare-s-bucket-structure-sizes/tests/judge_prompt.md
@@ -7,25 +7,27 @@ You will be shown two files in the user message:
    - `instruction`: the task itself (what the user asked).
    - `expected_answer`: the senior engineer's reference answer.
 
-## Evaluation Standard
+## General Guidance
+
+### Evaluation Standard
 
 The answers are EQUIVALENT if a practitioner following the junior's answer would reach the same conclusion and take the same effective action as someone following the senior's answer.
 
-## Must Match
+### Must Match
 
 - The primary root cause or diagnosis.
 - The overall verdict (broken/working, how many, which resource).
 - All distinct root causes if the senior identifies multiple.
 - If a fix is proposed: it must actually work. A command missing required parameters or targeting the wrong resource is NOT equivalent, even if the diagnosis is correct.
 
-## May Differ
+### May Differ
 
 - Wording, formatting, level of detail, or method of investigation.
 - Console URLs, dashboard links, retention periods, region names when obvious.
 - Additional correct information beyond the reference.
 - Formatting details of identifiers when the resource is unambiguously identified.
 
-## Fail If
+### Fail If
 
 1. Wrong verdict (broken vs working).
 2. Wrong root cause that would not explain or fix the problem.
@@ -34,19 +36,27 @@ The answers are EQUIVALENT if a practitioner following the junior's answer would
 5. Missing a primary root cause the senior identified.
 6. Introduces false claims about the infrastructure that would mislead a practitioner. Minor imprecisions in non-actionable details do not count.
 
-## Clarifications
+### Clarifications
 
 - Omitting a detail is acceptable UNLESS it changes what action a practitioner would take.
 - Merely mentioning an approach is not the same as providing it as the solution.
 - Listing more resources than the reference says exist is NOT equivalent.
 - If the junior answers with a question and the senior gives an explicit answer, NOT equivalent.
 
-## Steps
+### Steps
 
 1. Read the instruction to understand what was asked.
 2. Identify what action a practitioner would take from the senior's answer.
 3. Check if the junior's answer leads to the same effective action.
 4. Check if any Fail condition applies.
 5. If same effective action and no fail condition: EQUIVALENT.
+
+## Per-Claim Grading
+
+This task's reference answer has been decomposed into the individual claims listed below. Score each claim independently, on its own merits -- whether the junior's answer covers other listed claims should not affect this one.
+
+- For each claim, judge whether the junior's answer in agent-output.txt supports it, allowing for differences in wording, formatting, or level of detail per the Must Match / May Differ / Fail If rules above.
+- A claim about a fix or remediation step is satisfied when the junior proposes an equivalent fix; a claim about a root cause is satisfied when the junior identifies an equivalent cause.
+- EXCEPTION: the claim named `no_extraneous_or_contradicting_facts` (if listed below) is judged differently from every other claim here -- follow its own description, which judges the answer as a WHOLE against the ENTIRE reference answer, not one isolated fact.
 
 {criteria}

--- a/tasks/databases-and-storage/count-cfn-stacks-with-s-buckets/tests/judge.toml
+++ b/tasks/databases-and-storage/count-cfn-stacks-with-s-buckets/tests/judge.toml
@@ -5,9 +5,29 @@ files = [
     "/tests/ground_truth.json",
 ]
 prompt_template = "judge_prompt.md"
-mode = "individual"
+mode = "batched"
 
 [[criterion]]
-name = "answers_equivalent"
-description = "Are the junior engineer's findings equivalent to the senior engineer's reference answer per the rubric?"
+name = "in_us_east_1_00da49d8_totalstackswiths3_active_c"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): In us-east-1, {{00da49d8-TotalStacksWithS3}} active CloudFormation stacks declare an S3 bucket resource"
+type = "binary"
+
+[[criterion]]
+name = "00da49d8_regularbucketstackcount_contain_a_regul"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): {{00da49d8-RegularBucketStackCount}} contain a regular `AWS::S3::Bucket`"
+type = "binary"
+
+[[criterion]]
+name = "vector_buckets_aws_s3vectors_vectorbucket_are_de"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): the number of stacks declaring a vector bucket (`AWS::S3Vectors::VectorBucket`) matches what the reference states (the specific stack(s): {{00da49d8-VectorBucketStacks}}). The instruction's core ask is a count broken down by S3 variant -- do not require the junior to name the specific stack(s); crediting the correct per-variant count alone is sufficient."
+type = "binary"
+
+[[criterion]]
+name = "table_buckets_aws_s3tables_tablebucket_are_decla"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): the number of stacks declaring a table bucket (`AWS::S3Tables::TableBucket`) matches what the reference states (the specific stack(s): {{00da49d8-TableBucketStacks}}). The instruction's core ask is a count broken down by S3 variant -- do not require the junior to name the specific stack(s); crediting the correct per-variant count alone is sufficient."
+type = "binary"
+
+[[criterion]]
+name = "no_extraneous_or_contradicting_facts"
+description = "Per the rubric's Fail-If and Clarifications rules, does the junior engineer's answer AVOID both of the following: (1) stating any fact that contradicts the reference answer's stated infrastructure state (e.g. a different count, the wrong resource, an opposite status), and (2) claiming the existence of additional resources, findings, or facts beyond what the reference answer states, in a way that would mislead a practitioner into a different conclusion or action. Judge the junior's answer as a whole against the entire reference answer for this, not any single claim. Answer 'yes' if the junior's answer contains no such contradiction or unsupported extra claim; answer 'no' if it does."
 type = "binary"

--- a/tasks/databases-and-storage/count-cfn-stacks-with-s-buckets/tests/judge_prompt.md
+++ b/tasks/databases-and-storage/count-cfn-stacks-with-s-buckets/tests/judge_prompt.md
@@ -7,25 +7,27 @@ You will be shown two files in the user message:
    - `instruction`: the task itself (what the user asked).
    - `expected_answer`: the senior engineer's reference answer.
 
-## Evaluation Standard
+## General Guidance
+
+### Evaluation Standard
 
 The answers are EQUIVALENT if a practitioner following the junior's answer would reach the same conclusion and take the same effective action as someone following the senior's answer.
 
-## Must Match
+### Must Match
 
 - The primary root cause or diagnosis.
 - The overall verdict (broken/working, how many, which resource).
 - All distinct root causes if the senior identifies multiple.
 - If a fix is proposed: it must actually work. A command missing required parameters or targeting the wrong resource is NOT equivalent, even if the diagnosis is correct.
 
-## May Differ
+### May Differ
 
 - Wording, formatting, level of detail, or method of investigation.
 - Console URLs, dashboard links, retention periods, region names when obvious.
 - Additional correct information beyond the reference.
 - Formatting details of identifiers when the resource is unambiguously identified.
 
-## Fail If
+### Fail If
 
 1. Wrong verdict (broken vs working).
 2. Wrong root cause that would not explain or fix the problem.
@@ -34,19 +36,27 @@ The answers are EQUIVALENT if a practitioner following the junior's answer would
 5. Missing a primary root cause the senior identified.
 6. Introduces false claims about the infrastructure that would mislead a practitioner. Minor imprecisions in non-actionable details do not count.
 
-## Clarifications
+### Clarifications
 
 - Omitting a detail is acceptable UNLESS it changes what action a practitioner would take.
 - Merely mentioning an approach is not the same as providing it as the solution.
 - Listing more resources than the reference says exist is NOT equivalent.
 - If the junior answers with a question and the senior gives an explicit answer, NOT equivalent.
 
-## Steps
+### Steps
 
 1. Read the instruction to understand what was asked.
 2. Identify what action a practitioner would take from the senior's answer.
 3. Check if the junior's answer leads to the same effective action.
 4. Check if any Fail condition applies.
 5. If same effective action and no fail condition: EQUIVALENT.
+
+## Per-Claim Grading
+
+This task's reference answer has been decomposed into the individual claims listed below. Score each claim independently, on its own merits -- whether the junior's answer covers other listed claims should not affect this one.
+
+- For each claim, judge whether the junior's answer in agent-output.txt supports it, allowing for differences in wording, formatting, or level of detail per the Must Match / May Differ / Fail If rules above.
+- A claim about a fix or remediation step is satisfied when the junior proposes an equivalent fix; a claim about a root cause is satisfied when the junior identifies an equivalent cause.
+- EXCEPTION: the claim named `no_extraneous_or_contradicting_facts` (if listed below) is judged differently from every other claim here -- follow its own description, which judges the answer as a WHOLE against the ENTIRE reference answer, not one isolated fact.
 
 {criteria}

--- a/tasks/databases-and-storage/count-old-s-buckets/tests/judge.toml
+++ b/tasks/databases-and-storage/count-old-s-buckets/tests/judge.toml
@@ -5,9 +5,14 @@ files = [
     "/tests/ground_truth.json",
 ]
 prompt_template = "judge_prompt.md"
-mode = "individual"
+mode = "batched"
 
 [[criterion]]
-name = "answers_equivalent"
-description = "Are the junior engineer's findings equivalent to the senior engineer's reference answer per the rubric?"
+name = "you_have_c480b808_bucketcount_s3_buckets_that_we"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): You have {{c480b808-BucketCount}} S3 buckets that were created more than a day ago."
+type = "binary"
+
+[[criterion]]
+name = "no_extraneous_or_contradicting_facts"
+description = "Per the rubric's Fail-If and Clarifications rules, does the junior engineer's answer AVOID both of the following: (1) stating any fact that contradicts the reference answer's stated infrastructure state (e.g. a different count, the wrong resource, an opposite status), and (2) claiming the existence of additional resources, findings, or facts beyond what the reference answer states, in a way that would mislead a practitioner into a different conclusion or action. Judge the junior's answer as a whole against the entire reference answer for this, not any single claim. Answer 'yes' if the junior's answer contains no such contradiction or unsupported extra claim; answer 'no' if it does."
 type = "binary"

--- a/tasks/databases-and-storage/count-old-s-buckets/tests/judge_prompt.md
+++ b/tasks/databases-and-storage/count-old-s-buckets/tests/judge_prompt.md
@@ -7,25 +7,27 @@ You will be shown two files in the user message:
    - `instruction`: the task itself (what the user asked).
    - `expected_answer`: the senior engineer's reference answer.
 
-## Evaluation Standard
+## General Guidance
+
+### Evaluation Standard
 
 The answers are EQUIVALENT if a practitioner following the junior's answer would reach the same conclusion and take the same effective action as someone following the senior's answer.
 
-## Must Match
+### Must Match
 
 - The primary root cause or diagnosis.
 - The overall verdict (broken/working, how many, which resource).
 - All distinct root causes if the senior identifies multiple.
 - If a fix is proposed: it must actually work. A command missing required parameters or targeting the wrong resource is NOT equivalent, even if the diagnosis is correct.
 
-## May Differ
+### May Differ
 
 - Wording, formatting, level of detail, or method of investigation.
 - Console URLs, dashboard links, retention periods, region names when obvious.
 - Additional correct information beyond the reference.
 - Formatting details of identifiers when the resource is unambiguously identified.
 
-## Fail If
+### Fail If
 
 1. Wrong verdict (broken vs working).
 2. Wrong root cause that would not explain or fix the problem.
@@ -34,19 +36,27 @@ The answers are EQUIVALENT if a practitioner following the junior's answer would
 5. Missing a primary root cause the senior identified.
 6. Introduces false claims about the infrastructure that would mislead a practitioner. Minor imprecisions in non-actionable details do not count.
 
-## Clarifications
+### Clarifications
 
 - Omitting a detail is acceptable UNLESS it changes what action a practitioner would take.
 - Merely mentioning an approach is not the same as providing it as the solution.
 - Listing more resources than the reference says exist is NOT equivalent.
 - If the junior answers with a question and the senior gives an explicit answer, NOT equivalent.
 
-## Steps
+### Steps
 
 1. Read the instruction to understand what was asked.
 2. Identify what action a practitioner would take from the senior's answer.
 3. Check if the junior's answer leads to the same effective action.
 4. Check if any Fail condition applies.
 5. If same effective action and no fail condition: EQUIVALENT.
+
+## Per-Claim Grading
+
+This task's reference answer has been decomposed into the individual claims listed below. Score each claim independently, on its own merits -- whether the junior's answer covers other listed claims should not affect this one.
+
+- For each claim, judge whether the junior's answer in agent-output.txt supports it, allowing for differences in wording, formatting, or level of detail per the Must Match / May Differ / Fail If rules above.
+- A claim about a fix or remediation step is satisfied when the junior proposes an equivalent fix; a claim about a root cause is satisfied when the junior identifies an equivalent cause.
+- EXCEPTION: the claim named `no_extraneous_or_contradicting_facts` (if listed below) is judged differently from every other claim here -- follow its own description, which judges the answer as a WHOLE against the ENTIRE reference answer, not one isolated fact.
 
 {criteria}

--- a/tasks/databases-and-storage/count-sns-topic-sqs-subscribers/tests/judge.toml
+++ b/tasks/databases-and-storage/count-sns-topic-sqs-subscribers/tests/judge.toml
@@ -5,9 +5,14 @@ files = [
     "/tests/ground_truth.json",
 ]
 prompt_template = "judge_prompt.md"
-mode = "individual"
+mode = "batched"
 
 [[criterion]]
-name = "answers_equivalent"
-description = "Are the junior engineer's findings equivalent to the senior engineer's reference answer per the rubric?"
+name = "the_total_number_of_subscribers_subscribed_to_al"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The total number of subscribers subscribed to all SNS topics in us-west-2 is {{databases-and-storage-SQS-e5ldy6q5p-us-west-2-NUMSubscribers}}."
+type = "binary"
+
+[[criterion]]
+name = "no_extraneous_or_contradicting_facts"
+description = "Per the rubric's Fail-If and Clarifications rules, does the junior engineer's answer AVOID both of the following: (1) stating any fact that contradicts the reference answer's stated infrastructure state (e.g. a different count, the wrong resource, an opposite status), and (2) claiming the existence of additional resources, findings, or facts beyond what the reference answer states, in a way that would mislead a practitioner into a different conclusion or action. Judge the junior's answer as a whole against the entire reference answer for this, not any single claim. Answer 'yes' if the junior's answer contains no such contradiction or unsupported extra claim; answer 'no' if it does."
 type = "binary"

--- a/tasks/databases-and-storage/count-sns-topic-sqs-subscribers/tests/judge_prompt.md
+++ b/tasks/databases-and-storage/count-sns-topic-sqs-subscribers/tests/judge_prompt.md
@@ -7,25 +7,27 @@ You will be shown two files in the user message:
    - `instruction`: the task itself (what the user asked).
    - `expected_answer`: the senior engineer's reference answer.
 
-## Evaluation Standard
+## General Guidance
+
+### Evaluation Standard
 
 The answers are EQUIVALENT if a practitioner following the junior's answer would reach the same conclusion and take the same effective action as someone following the senior's answer.
 
-## Must Match
+### Must Match
 
 - The primary root cause or diagnosis.
 - The overall verdict (broken/working, how many, which resource).
 - All distinct root causes if the senior identifies multiple.
 - If a fix is proposed: it must actually work. A command missing required parameters or targeting the wrong resource is NOT equivalent, even if the diagnosis is correct.
 
-## May Differ
+### May Differ
 
 - Wording, formatting, level of detail, or method of investigation.
 - Console URLs, dashboard links, retention periods, region names when obvious.
 - Additional correct information beyond the reference.
 - Formatting details of identifiers when the resource is unambiguously identified.
 
-## Fail If
+### Fail If
 
 1. Wrong verdict (broken vs working).
 2. Wrong root cause that would not explain or fix the problem.
@@ -34,19 +36,27 @@ The answers are EQUIVALENT if a practitioner following the junior's answer would
 5. Missing a primary root cause the senior identified.
 6. Introduces false claims about the infrastructure that would mislead a practitioner. Minor imprecisions in non-actionable details do not count.
 
-## Clarifications
+### Clarifications
 
 - Omitting a detail is acceptable UNLESS it changes what action a practitioner would take.
 - Merely mentioning an approach is not the same as providing it as the solution.
 - Listing more resources than the reference says exist is NOT equivalent.
 - If the junior answers with a question and the senior gives an explicit answer, NOT equivalent.
 
-## Steps
+### Steps
 
 1. Read the instruction to understand what was asked.
 2. Identify what action a practitioner would take from the senior's answer.
 3. Check if the junior's answer leads to the same effective action.
 4. Check if any Fail condition applies.
 5. If same effective action and no fail condition: EQUIVALENT.
+
+## Per-Claim Grading
+
+This task's reference answer has been decomposed into the individual claims listed below. Score each claim independently, on its own merits -- whether the junior's answer covers other listed claims should not affect this one.
+
+- For each claim, judge whether the junior's answer in agent-output.txt supports it, allowing for differences in wording, formatting, or level of detail per the Must Match / May Differ / Fail If rules above.
+- A claim about a fix or remediation step is satisfied when the junior proposes an equivalent fix; a claim about a root cause is satisfied when the junior identifies an equivalent cause.
+- EXCEPTION: the claim named `no_extraneous_or_contradicting_facts` (if listed below) is judged differently from every other claim here -- follow its own description, which judges the answer as a WHOLE against the ENTIRE reference answer, not one isolated fact.
 
 {criteria}

--- a/tasks/databases-and-storage/count-windows-server-managed-nodes/tests/judge.toml
+++ b/tasks/databases-and-storage/count-windows-server-managed-nodes/tests/judge.toml
@@ -5,9 +5,14 @@ files = [
     "/tests/ground_truth.json",
 ]
 prompt_template = "judge_prompt.md"
-mode = "individual"
+mode = "batched"
 
 [[criterion]]
-name = "answers_equivalent"
-description = "Are the junior engineer's findings equivalent to the senior engineer's reference answer per the rubric?"
+name = "you_have_databases_and_storage_ssm_a1b2c3d46_us_"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): You have {{databases-and-storage-SSM-a1b2c3d46-us-east-1-NumberOfWindows2022ManagedNodes}} Windows Server 2022 managed node in us-east-1."
+type = "binary"
+
+[[criterion]]
+name = "no_extraneous_or_contradicting_facts"
+description = "Per the rubric's Fail-If and Clarifications rules, does the junior engineer's answer AVOID both of the following: (1) stating any fact that contradicts the reference answer's stated infrastructure state (e.g. a different count, the wrong resource, an opposite status), and (2) claiming the existence of additional resources, findings, or facts beyond what the reference answer states, in a way that would mislead a practitioner into a different conclusion or action. Judge the junior's answer as a whole against the entire reference answer for this, not any single claim. Answer 'yes' if the junior's answer contains no such contradiction or unsupported extra claim; answer 'no' if it does."
 type = "binary"

--- a/tasks/databases-and-storage/count-windows-server-managed-nodes/tests/judge_prompt.md
+++ b/tasks/databases-and-storage/count-windows-server-managed-nodes/tests/judge_prompt.md
@@ -7,25 +7,27 @@ You will be shown two files in the user message:
    - `instruction`: the task itself (what the user asked).
    - `expected_answer`: the senior engineer's reference answer.
 
-## Evaluation Standard
+## General Guidance
+
+### Evaluation Standard
 
 The answers are EQUIVALENT if a practitioner following the junior's answer would reach the same conclusion and take the same effective action as someone following the senior's answer.
 
-## Must Match
+### Must Match
 
 - The primary root cause or diagnosis.
 - The overall verdict (broken/working, how many, which resource).
 - All distinct root causes if the senior identifies multiple.
 - If a fix is proposed: it must actually work. A command missing required parameters or targeting the wrong resource is NOT equivalent, even if the diagnosis is correct.
 
-## May Differ
+### May Differ
 
 - Wording, formatting, level of detail, or method of investigation.
 - Console URLs, dashboard links, retention periods, region names when obvious.
 - Additional correct information beyond the reference.
 - Formatting details of identifiers when the resource is unambiguously identified.
 
-## Fail If
+### Fail If
 
 1. Wrong verdict (broken vs working).
 2. Wrong root cause that would not explain or fix the problem.
@@ -34,19 +36,27 @@ The answers are EQUIVALENT if a practitioner following the junior's answer would
 5. Missing a primary root cause the senior identified.
 6. Introduces false claims about the infrastructure that would mislead a practitioner. Minor imprecisions in non-actionable details do not count.
 
-## Clarifications
+### Clarifications
 
 - Omitting a detail is acceptable UNLESS it changes what action a practitioner would take.
 - Merely mentioning an approach is not the same as providing it as the solution.
 - Listing more resources than the reference says exist is NOT equivalent.
 - If the junior answers with a question and the senior gives an explicit answer, NOT equivalent.
 
-## Steps
+### Steps
 
 1. Read the instruction to understand what was asked.
 2. Identify what action a practitioner would take from the senior's answer.
 3. Check if the junior's answer leads to the same effective action.
 4. Check if any Fail condition applies.
 5. If same effective action and no fail condition: EQUIVALENT.
+
+## Per-Claim Grading
+
+This task's reference answer has been decomposed into the individual claims listed below. Score each claim independently, on its own merits -- whether the junior's answer covers other listed claims should not affect this one.
+
+- For each claim, judge whether the junior's answer in agent-output.txt supports it, allowing for differences in wording, formatting, or level of detail per the Must Match / May Differ / Fail If rules above.
+- A claim about a fix or remediation step is satisfied when the junior proposes an equivalent fix; a claim about a root cause is satisfied when the junior identifies an equivalent cause.
+- EXCEPTION: the claim named `no_extraneous_or_contradicting_facts` (if listed below) is judged differently from every other claim here -- follow its own description, which judges the answer as a WHOLE against the ENTIRE reference answer, not one isolated fact.
 
 {criteria}

--- a/tasks/databases-and-storage/dynamodb-query-workflow-status-analysis/tests/judge.toml
+++ b/tasks/databases-and-storage/dynamodb-query-workflow-status-analysis/tests/judge.toml
@@ -5,9 +5,49 @@ files = [
     "/tests/ground_truth.json",
 ]
 prompt_template = "judge_prompt.md"
-mode = "individual"
+mode = "batched"
 
 [[criterion]]
-name = "answers_equivalent"
-description = "Are the junior engineer's findings equivalent to the senior engineer's reference answer per the rubric?"
+name = "record_with_id_web_003_has_workflowid_wf_alpha_a"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): Record with id=web-003 has workflowId=wf-alpha and status=completed"
+type = "binary"
+
+[[criterion]]
+name = "record_with_id_web_001_has_workflowid_wf_alpha_a"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): Record with id=web-001 has workflowId=wf-alpha and status=completed"
+type = "binary"
+
+[[criterion]]
+name = "record_with_id_web_002_has_workflowid_wf_beta_an"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): Record with id=web-002 has workflowId=wf-beta and status=processing"
+type = "binary"
+
+[[criterion]]
+name = "2_records_have_status_completed"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): 2 records have status \"completed\""
+type = "binary"
+
+[[criterion]]
+name = "3_total_records_scanned"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): 3 total records scanned. The instruction only asks for sample records, the completed-status count, and the unique workflow ID list -- it does not ask for an explicit total-scanned count. Credit this claim if the junior's shown records/answer are consistent with a total of 3 and do not contradict it, even if the junior never explicitly states the total."
+type = "binary"
+
+[[criterion]]
+name = "wf_alpha_appears_2_times"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): wf-alpha appears 2 times. The instruction only asks for the list of unique workflow IDs, not their frequency counts -- credit this claim if the junior's shown sample records are consistent with wf-alpha appearing 2 times and do not contradict it, even if the junior never explicitly restates the count."
+type = "binary"
+
+[[criterion]]
+name = "wf_beta_appears_1_time"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): wf-beta appears 1 time. The instruction only asks for the list of unique workflow IDs, not their frequency counts -- credit this claim if the junior's shown sample records are consistent with wf-beta appearing 1 time and do not contradict it, even if the junior never explicitly restates the count."
+type = "binary"
+
+[[criterion]]
+name = "the_table_contains_2_unique_workflow_ids"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The table contains 2 unique workflow IDs"
+type = "binary"
+
+[[criterion]]
+name = "no_extraneous_or_contradicting_facts"
+description = "Per the rubric's Fail-If and Clarifications rules, does the junior engineer's answer AVOID both of the following: (1) stating any fact that contradicts the reference answer's stated infrastructure state (e.g. a different count, the wrong resource, an opposite status), and (2) claiming the existence of additional resources, findings, or facts beyond what the reference answer states, in a way that would mislead a practitioner into a different conclusion or action. Judge the junior's answer as a whole against the entire reference answer for this, not any single claim. Answer 'yes' if the junior's answer contains no such contradiction or unsupported extra claim; answer 'no' if it does."
 type = "binary"

--- a/tasks/databases-and-storage/dynamodb-query-workflow-status-analysis/tests/judge_prompt.md
+++ b/tasks/databases-and-storage/dynamodb-query-workflow-status-analysis/tests/judge_prompt.md
@@ -7,25 +7,27 @@ You will be shown two files in the user message:
    - `instruction`: the task itself (what the user asked).
    - `expected_answer`: the senior engineer's reference answer.
 
-## Evaluation Standard
+## General Guidance
+
+### Evaluation Standard
 
 The answers are EQUIVALENT if a practitioner following the junior's answer would reach the same conclusion and take the same effective action as someone following the senior's answer.
 
-## Must Match
+### Must Match
 
 - The primary root cause or diagnosis.
 - The overall verdict (broken/working, how many, which resource).
 - All distinct root causes if the senior identifies multiple.
 - If a fix is proposed: it must actually work. A command missing required parameters or targeting the wrong resource is NOT equivalent, even if the diagnosis is correct.
 
-## May Differ
+### May Differ
 
 - Wording, formatting, level of detail, or method of investigation.
 - Console URLs, dashboard links, retention periods, region names when obvious.
 - Additional correct information beyond the reference.
 - Formatting details of identifiers when the resource is unambiguously identified.
 
-## Fail If
+### Fail If
 
 1. Wrong verdict (broken vs working).
 2. Wrong root cause that would not explain or fix the problem.
@@ -34,19 +36,27 @@ The answers are EQUIVALENT if a practitioner following the junior's answer would
 5. Missing a primary root cause the senior identified.
 6. Introduces false claims about the infrastructure that would mislead a practitioner. Minor imprecisions in non-actionable details do not count.
 
-## Clarifications
+### Clarifications
 
 - Omitting a detail is acceptable UNLESS it changes what action a practitioner would take.
 - Merely mentioning an approach is not the same as providing it as the solution.
 - Listing more resources than the reference says exist is NOT equivalent.
 - If the junior answers with a question and the senior gives an explicit answer, NOT equivalent.
 
-## Steps
+### Steps
 
 1. Read the instruction to understand what was asked.
 2. Identify what action a practitioner would take from the senior's answer.
 3. Check if the junior's answer leads to the same effective action.
 4. Check if any Fail condition applies.
 5. If same effective action and no fail condition: EQUIVALENT.
+
+## Per-Claim Grading
+
+This task's reference answer has been decomposed into the individual claims listed below. Score each claim independently, on its own merits -- whether the junior's answer covers other listed claims should not affect this one.
+
+- For each claim, judge whether the junior's answer in agent-output.txt supports it, allowing for differences in wording, formatting, or level of detail per the Must Match / May Differ / Fail If rules above.
+- A claim about a fix or remediation step is satisfied when the junior proposes an equivalent fix; a claim about a root cause is satisfied when the junior identifies an equivalent cause.
+- EXCEPTION: the claim named `no_extraneous_or_contradicting_facts` (if listed below) is judged differently from every other claim here -- follow its own description, which judges the answer as a WHOLE against the ENTIRE reference answer, not one isolated fact.
 
 {criteria}

--- a/tasks/databases-and-storage/dynamodb-scan-and-fetch-record/tests/judge.toml
+++ b/tasks/databases-and-storage/dynamodb-scan-and-fetch-record/tests/judge.toml
@@ -5,9 +5,39 @@ files = [
     "/tests/ground_truth.json",
 ]
 prompt_template = "judge_prompt.md"
-mode = "individual"
+mode = "batched"
 
 [[criterion]]
-name = "answers_equivalent"
-description = "Are the junior engineer's findings equivalent to the senior engineer's reference answer per the rubric?"
+name = "the_scan_of_dynamodb_table_databases_and_storage"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The scan of DynamoDB table {{databases-and-storage-dynamodb-ghjk456ad-us-east-1-TableName}} returned 20 items"
+type = "binary"
+
+[[criterion]]
+name = "the_record_with_contentid_databases_and_storage_"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The record with ContentId {{databases-and-storage-dynamodb-ghjk456ad-us-east-1-ContentId}} has TaskId TASK012"
+type = "binary"
+
+[[criterion]]
+name = "the_record_with_contentid_databases_and_storage__2"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The record with ContentId {{databases-and-storage-dynamodb-ghjk456ad-us-east-1-ContentId}} has Description 'Database backup'"
+type = "binary"
+
+[[criterion]]
+name = "the_record_with_contentid_databases_and_storage__3"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The record with ContentId {{databases-and-storage-dynamodb-ghjk456ad-us-east-1-ContentId}} has Priority LOW"
+type = "binary"
+
+[[criterion]]
+name = "the_record_with_contentid_databases_and_storage__4"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The record with ContentId {{databases-and-storage-dynamodb-ghjk456ad-us-east-1-ContentId}} has TaskStatus BLOCKED"
+type = "binary"
+
+[[criterion]]
+name = "the_record_with_contentid_databases_and_storage__5"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The record with ContentId {{databases-and-storage-dynamodb-ghjk456ad-us-east-1-ContentId}} is assigned to user4@example.com"
+type = "binary"
+
+[[criterion]]
+name = "no_extraneous_or_contradicting_facts"
+description = "Per the rubric's Fail-If and Clarifications rules, does the junior engineer's answer AVOID both of the following: (1) stating any fact that contradicts the reference answer's stated infrastructure state (e.g. a different count, the wrong resource, an opposite status), and (2) claiming the existence of additional resources, findings, or facts beyond what the reference answer states, in a way that would mislead a practitioner into a different conclusion or action. Judge the junior's answer as a whole against the entire reference answer for this, not any single claim. Answer 'yes' if the junior's answer contains no such contradiction or unsupported extra claim; answer 'no' if it does."
 type = "binary"

--- a/tasks/databases-and-storage/dynamodb-scan-and-fetch-record/tests/judge_prompt.md
+++ b/tasks/databases-and-storage/dynamodb-scan-and-fetch-record/tests/judge_prompt.md
@@ -7,25 +7,27 @@ You will be shown two files in the user message:
    - `instruction`: the task itself (what the user asked).
    - `expected_answer`: the senior engineer's reference answer.
 
-## Evaluation Standard
+## General Guidance
+
+### Evaluation Standard
 
 The answers are EQUIVALENT if a practitioner following the junior's answer would reach the same conclusion and take the same effective action as someone following the senior's answer.
 
-## Must Match
+### Must Match
 
 - The primary root cause or diagnosis.
 - The overall verdict (broken/working, how many, which resource).
 - All distinct root causes if the senior identifies multiple.
 - If a fix is proposed: it must actually work. A command missing required parameters or targeting the wrong resource is NOT equivalent, even if the diagnosis is correct.
 
-## May Differ
+### May Differ
 
 - Wording, formatting, level of detail, or method of investigation.
 - Console URLs, dashboard links, retention periods, region names when obvious.
 - Additional correct information beyond the reference.
 - Formatting details of identifiers when the resource is unambiguously identified.
 
-## Fail If
+### Fail If
 
 1. Wrong verdict (broken vs working).
 2. Wrong root cause that would not explain or fix the problem.
@@ -34,19 +36,27 @@ The answers are EQUIVALENT if a practitioner following the junior's answer would
 5. Missing a primary root cause the senior identified.
 6. Introduces false claims about the infrastructure that would mislead a practitioner. Minor imprecisions in non-actionable details do not count.
 
-## Clarifications
+### Clarifications
 
 - Omitting a detail is acceptable UNLESS it changes what action a practitioner would take.
 - Merely mentioning an approach is not the same as providing it as the solution.
 - Listing more resources than the reference says exist is NOT equivalent.
 - If the junior answers with a question and the senior gives an explicit answer, NOT equivalent.
 
-## Steps
+### Steps
 
 1. Read the instruction to understand what was asked.
 2. Identify what action a practitioner would take from the senior's answer.
 3. Check if the junior's answer leads to the same effective action.
 4. Check if any Fail condition applies.
 5. If same effective action and no fail condition: EQUIVALENT.
+
+## Per-Claim Grading
+
+This task's reference answer has been decomposed into the individual claims listed below. Score each claim independently, on its own merits -- whether the junior's answer covers other listed claims should not affect this one.
+
+- For each claim, judge whether the junior's answer in agent-output.txt supports it, allowing for differences in wording, formatting, or level of detail per the Must Match / May Differ / Fail If rules above.
+- A claim about a fix or remediation step is satisfied when the junior proposes an equivalent fix; a claim about a root cause is satisfied when the junior identifies an equivalent cause.
+- EXCEPTION: the claim named `no_extraneous_or_contradicting_facts` (if listed below) is judged differently from every other claim here -- follow its own description, which judges the answer as a WHOLE against the ENTIRE reference answer, not one isolated fact.
 
 {criteria}

--- a/tasks/databases-and-storage/dynamodb-scan-filter-by-attribute/tests/judge.toml
+++ b/tasks/databases-and-storage/dynamodb-scan-filter-by-attribute/tests/judge.toml
@@ -5,9 +5,34 @@ files = [
     "/tests/ground_truth.json",
 ]
 prompt_template = "judge_prompt.md"
-mode = "individual"
+mode = "batched"
 
 [[criterion]]
-name = "answers_equivalent"
-description = "Are the junior engineer's findings equivalent to the senior engineer's reference answer per the rubric?"
+name = "the_dynamodb_table_databases_and_storage_dynamod"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The DynamoDB table {{databases-and-storage-dynamodb-gsdf23tr4-us-east-1-TableName}} scan has been completed successfully"
+type = "binary"
+
+[[criterion]]
+name = "the_scan_retrieved_all_items_containing_the_spec"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The scan retrieved all items containing the specified attributes {{databases-and-storage-dynamodb-gsdf23tr4-us-east-1-AttributeNames}}"
+type = "binary"
+
+[[criterion]]
+name = "found_3_items_total_in_the_table"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): Found 3 items total in the table"
+type = "binary"
+
+[[criterion]]
+name = "1_item_with_status_inactive"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): 1 item with status \"inactive\""
+type = "binary"
+
+[[criterion]]
+name = "2_items_with_status_active"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): 2 items with status \"active\""
+type = "binary"
+
+[[criterion]]
+name = "no_extraneous_or_contradicting_facts"
+description = "Per the rubric's Fail-If and Clarifications rules, does the junior engineer's answer AVOID both of the following: (1) stating any fact that contradicts the reference answer's stated infrastructure state (e.g. a different count, the wrong resource, an opposite status), and (2) claiming the existence of additional resources, findings, or facts beyond what the reference answer states, in a way that would mislead a practitioner into a different conclusion or action. Judge the junior's answer as a whole against the entire reference answer for this, not any single claim. Answer 'yes' if the junior's answer contains no such contradiction or unsupported extra claim; answer 'no' if it does."
 type = "binary"

--- a/tasks/databases-and-storage/dynamodb-scan-filter-by-attribute/tests/judge_prompt.md
+++ b/tasks/databases-and-storage/dynamodb-scan-filter-by-attribute/tests/judge_prompt.md
@@ -7,25 +7,27 @@ You will be shown two files in the user message:
    - `instruction`: the task itself (what the user asked).
    - `expected_answer`: the senior engineer's reference answer.
 
-## Evaluation Standard
+## General Guidance
+
+### Evaluation Standard
 
 The answers are EQUIVALENT if a practitioner following the junior's answer would reach the same conclusion and take the same effective action as someone following the senior's answer.
 
-## Must Match
+### Must Match
 
 - The primary root cause or diagnosis.
 - The overall verdict (broken/working, how many, which resource).
 - All distinct root causes if the senior identifies multiple.
 - If a fix is proposed: it must actually work. A command missing required parameters or targeting the wrong resource is NOT equivalent, even if the diagnosis is correct.
 
-## May Differ
+### May Differ
 
 - Wording, formatting, level of detail, or method of investigation.
 - Console URLs, dashboard links, retention periods, region names when obvious.
 - Additional correct information beyond the reference.
 - Formatting details of identifiers when the resource is unambiguously identified.
 
-## Fail If
+### Fail If
 
 1. Wrong verdict (broken vs working).
 2. Wrong root cause that would not explain or fix the problem.
@@ -34,19 +36,27 @@ The answers are EQUIVALENT if a practitioner following the junior's answer would
 5. Missing a primary root cause the senior identified.
 6. Introduces false claims about the infrastructure that would mislead a practitioner. Minor imprecisions in non-actionable details do not count.
 
-## Clarifications
+### Clarifications
 
 - Omitting a detail is acceptable UNLESS it changes what action a practitioner would take.
 - Merely mentioning an approach is not the same as providing it as the solution.
 - Listing more resources than the reference says exist is NOT equivalent.
 - If the junior answers with a question and the senior gives an explicit answer, NOT equivalent.
 
-## Steps
+### Steps
 
 1. Read the instruction to understand what was asked.
 2. Identify what action a practitioner would take from the senior's answer.
 3. Check if the junior's answer leads to the same effective action.
 4. Check if any Fail condition applies.
 5. If same effective action and no fail condition: EQUIVALENT.
+
+## Per-Claim Grading
+
+This task's reference answer has been decomposed into the individual claims listed below. Score each claim independently, on its own merits -- whether the junior's answer covers other listed claims should not affect this one.
+
+- For each claim, judge whether the junior's answer in agent-output.txt supports it, allowing for differences in wording, formatting, or level of detail per the Must Match / May Differ / Fail If rules above.
+- A claim about a fix or remediation step is satisfied when the junior proposes an equivalent fix; a claim about a root cause is satisfied when the junior identifies an equivalent cause.
+- EXCEPTION: the claim named `no_extraneous_or_contradicting_facts` (if listed below) is judged differently from every other claim here -- follow its own description, which judges the answer as a WHOLE against the ENTIRE reference answer, not one isolated fact.
 
 {criteria}

--- a/tasks/databases-and-storage/dynamodb-tables-resource-based-policy/tests/judge.toml
+++ b/tasks/databases-and-storage/dynamodb-tables-resource-based-policy/tests/judge.toml
@@ -5,9 +5,19 @@ files = [
     "/tests/ground_truth.json",
 ]
 prompt_template = "judge_prompt.md"
-mode = "individual"
+mode = "batched"
 
 [[criterion]]
-name = "answers_equivalent"
-description = "Are the junior engineer's findings equivalent to the senior engineer's reference answer per the rubric?"
+name = "the_dynamodb_table_named_databases_and_storage_d"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The DynamoDB table named {{databases-and-storage-DynamoDB-a9d78fhs7-us-east-1-DynamoDBTableTableWithPolicy}} in the us-east-1 region has a resource-based policy"
+type = "binary"
+
+[[criterion]]
+name = "the_dynamodb_table_named_databases_and_storage_d_2"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The DynamoDB table named {{databases-and-storage-DynamoDB-a9d78fhs7-us-west-2-DynamoDBTableTableWithPolicy}} in the us-west-2 region has a resource-based policy"
+type = "binary"
+
+[[criterion]]
+name = "no_extraneous_or_contradicting_facts"
+description = "Per the rubric's Fail-If and Clarifications rules, does the junior engineer's answer AVOID both of the following: (1) stating any fact that contradicts the reference answer's stated infrastructure state (e.g. a different count, the wrong resource, an opposite status), and (2) claiming the existence of additional resources, findings, or facts beyond what the reference answer states, in a way that would mislead a practitioner into a different conclusion or action. Judge the junior's answer as a whole against the entire reference answer for this, not any single claim. Answer 'yes' if the junior's answer contains no such contradiction or unsupported extra claim; answer 'no' if it does."
 type = "binary"

--- a/tasks/databases-and-storage/dynamodb-tables-resource-based-policy/tests/judge_prompt.md
+++ b/tasks/databases-and-storage/dynamodb-tables-resource-based-policy/tests/judge_prompt.md
@@ -7,25 +7,27 @@ You will be shown two files in the user message:
    - `instruction`: the task itself (what the user asked).
    - `expected_answer`: the senior engineer's reference answer.
 
-## Evaluation Standard
+## General Guidance
+
+### Evaluation Standard
 
 The answers are EQUIVALENT if a practitioner following the junior's answer would reach the same conclusion and take the same effective action as someone following the senior's answer.
 
-## Must Match
+### Must Match
 
 - The primary root cause or diagnosis.
 - The overall verdict (broken/working, how many, which resource).
 - All distinct root causes if the senior identifies multiple.
 - If a fix is proposed: it must actually work. A command missing required parameters or targeting the wrong resource is NOT equivalent, even if the diagnosis is correct.
 
-## May Differ
+### May Differ
 
 - Wording, formatting, level of detail, or method of investigation.
 - Console URLs, dashboard links, retention periods, region names when obvious.
 - Additional correct information beyond the reference.
 - Formatting details of identifiers when the resource is unambiguously identified.
 
-## Fail If
+### Fail If
 
 1. Wrong verdict (broken vs working).
 2. Wrong root cause that would not explain or fix the problem.
@@ -34,19 +36,27 @@ The answers are EQUIVALENT if a practitioner following the junior's answer would
 5. Missing a primary root cause the senior identified.
 6. Introduces false claims about the infrastructure that would mislead a practitioner. Minor imprecisions in non-actionable details do not count.
 
-## Clarifications
+### Clarifications
 
 - Omitting a detail is acceptable UNLESS it changes what action a practitioner would take.
 - Merely mentioning an approach is not the same as providing it as the solution.
 - Listing more resources than the reference says exist is NOT equivalent.
 - If the junior answers with a question and the senior gives an explicit answer, NOT equivalent.
 
-## Steps
+### Steps
 
 1. Read the instruction to understand what was asked.
 2. Identify what action a practitioner would take from the senior's answer.
 3. Check if the junior's answer leads to the same effective action.
 4. Check if any Fail condition applies.
 5. If same effective action and no fail condition: EQUIVALENT.
+
+## Per-Claim Grading
+
+This task's reference answer has been decomposed into the individual claims listed below. Score each claim independently, on its own merits -- whether the junior's answer covers other listed claims should not affect this one.
+
+- For each claim, judge whether the junior's answer in agent-output.txt supports it, allowing for differences in wording, formatting, or level of detail per the Must Match / May Differ / Fail If rules above.
+- A claim about a fix or remediation step is satisfied when the junior proposes an equivalent fix; a claim about a root cause is satisfied when the junior identifies an equivalent cause.
+- EXCEPTION: the claim named `no_extraneous_or_contradicting_facts` (if listed below) is judged differently from every other claim here -- follow its own description, which judges the answer as a WHOLE against the ENTIRE reference answer, not one isolated fact.
 
 {criteria}

--- a/tasks/databases-and-storage/estimate-ec-running-instance-costs/tests/judge.toml
+++ b/tasks/databases-and-storage/estimate-ec-running-instance-costs/tests/judge.toml
@@ -5,9 +5,19 @@ files = [
     "/tests/ground_truth.json",
 ]
 prompt_template = "judge_prompt.md"
-mode = "individual"
+mode = "batched"
 
 [[criterion]]
-name = "answers_equivalent"
-description = "Are the junior engineer's findings equivalent to the senior engineer's reference answer per the rubric?"
+name = "the_total_estimated_hourly_on_demand_cost_is_f62"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The total estimated hourly on-demand cost is {{f6287f43-TotalHourlyCost}}"
+type = "binary"
+
+[[criterion]]
+name = "the_breakdown_by_instance_type_and_operating_sys"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The breakdown by instance type and operating system is {{f6287f43-Breakdown}}"
+type = "binary"
+
+[[criterion]]
+name = "no_extraneous_or_contradicting_facts"
+description = "Per the rubric's Fail-If and Clarifications rules, does the junior engineer's answer AVOID both of the following: (1) stating any fact that contradicts the reference answer's stated infrastructure state (e.g. a different count, the wrong resource, an opposite status), and (2) claiming the existence of additional resources, findings, or facts beyond what the reference answer states, in a way that would mislead a practitioner into a different conclusion or action. Judge the junior's answer as a whole against the entire reference answer for this, not any single claim. Answer 'yes' if the junior's answer contains no such contradiction or unsupported extra claim; answer 'no' if it does."
 type = "binary"

--- a/tasks/databases-and-storage/estimate-ec-running-instance-costs/tests/judge_prompt.md
+++ b/tasks/databases-and-storage/estimate-ec-running-instance-costs/tests/judge_prompt.md
@@ -7,25 +7,27 @@ You will be shown two files in the user message:
    - `instruction`: the task itself (what the user asked).
    - `expected_answer`: the senior engineer's reference answer.
 
-## Evaluation Standard
+## General Guidance
+
+### Evaluation Standard
 
 The answers are EQUIVALENT if a practitioner following the junior's answer would reach the same conclusion and take the same effective action as someone following the senior's answer.
 
-## Must Match
+### Must Match
 
 - The primary root cause or diagnosis.
 - The overall verdict (broken/working, how many, which resource).
 - All distinct root causes if the senior identifies multiple.
 - If a fix is proposed: it must actually work. A command missing required parameters or targeting the wrong resource is NOT equivalent, even if the diagnosis is correct.
 
-## May Differ
+### May Differ
 
 - Wording, formatting, level of detail, or method of investigation.
 - Console URLs, dashboard links, retention periods, region names when obvious.
 - Additional correct information beyond the reference.
 - Formatting details of identifiers when the resource is unambiguously identified.
 
-## Fail If
+### Fail If
 
 1. Wrong verdict (broken vs working).
 2. Wrong root cause that would not explain or fix the problem.
@@ -34,19 +36,27 @@ The answers are EQUIVALENT if a practitioner following the junior's answer would
 5. Missing a primary root cause the senior identified.
 6. Introduces false claims about the infrastructure that would mislead a practitioner. Minor imprecisions in non-actionable details do not count.
 
-## Clarifications
+### Clarifications
 
 - Omitting a detail is acceptable UNLESS it changes what action a practitioner would take.
 - Merely mentioning an approach is not the same as providing it as the solution.
 - Listing more resources than the reference says exist is NOT equivalent.
 - If the junior answers with a question and the senior gives an explicit answer, NOT equivalent.
 
-## Steps
+### Steps
 
 1. Read the instruction to understand what was asked.
 2. Identify what action a practitioner would take from the senior's answer.
 3. Check if the junior's answer leads to the same effective action.
 4. Check if any Fail condition applies.
 5. If same effective action and no fail condition: EQUIVALENT.
+
+## Per-Claim Grading
+
+This task's reference answer has been decomposed into the individual claims listed below. Score each claim independently, on its own merits -- whether the junior's answer covers other listed claims should not affect this one.
+
+- For each claim, judge whether the junior's answer in agent-output.txt supports it, allowing for differences in wording, formatting, or level of detail per the Must Match / May Differ / Fail If rules above.
+- A claim about a fix or remediation step is satisfied when the junior proposes an equivalent fix; a claim about a root cause is satisfied when the junior identifies an equivalent cause.
+- EXCEPTION: the claim named `no_extraneous_or_contradicting_facts` (if listed below) is judged differently from every other claim here -- follow its own description, which judges the answer as a WHOLE against the ENTIRE reference answer, not one isolated fact.
 
 {criteria}

--- a/tasks/databases-and-storage/get-s-bucket-ownership-controls/tests/judge.toml
+++ b/tasks/databases-and-storage/get-s-bucket-ownership-controls/tests/judge.toml
@@ -5,9 +5,24 @@ files = [
     "/tests/ground_truth.json",
 ]
 prompt_template = "judge_prompt.md"
-mode = "individual"
+mode = "batched"
 
 [[criterion]]
-name = "answers_equivalent"
-description = "Are the junior engineer's findings equivalent to the senior engineer's reference answer per the rubric?"
+name = "the_object_ownership_for_databases_and_storage_s"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The object ownership for {{databases-and-storage-S3-18475e2fc-us-east-1-EmptyS3Bucket1}} is {{databases-and-storage-S3-18475e2fc-us-east-1-ACLStatus1}}"
+type = "binary"
+
+[[criterion]]
+name = "the_object_ownership_for_databases_and_storage_s_2"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The object ownership for {{databases-and-storage-S3-18475e2fc-us-east-1-EmptyS3Bucket2}} is {{databases-and-storage-S3-18475e2fc-us-east-1-ACLStatus1}}"
+type = "binary"
+
+[[criterion]]
+name = "the_object_ownership_for_databases_and_storage_s_3"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The object ownership for {{databases-and-storage-S3-18475e2fc-us-east-1-S3BucketWithLifeCycleRules}} is {{databases-and-storage-S3-18475e2fc-us-east-1-ACLStatus3}}"
+type = "binary"
+
+[[criterion]]
+name = "no_extraneous_or_contradicting_facts"
+description = "Per the rubric's Fail-If and Clarifications rules, does the junior engineer's answer AVOID both of the following: (1) stating any fact that contradicts the reference answer's stated infrastructure state (e.g. a different count, the wrong resource, an opposite status), and (2) claiming the existence of additional resources, findings, or facts beyond what the reference answer states, in a way that would mislead a practitioner into a different conclusion or action. Judge the junior's answer as a whole against the entire reference answer for this, not any single claim. Answer 'yes' if the junior's answer contains no such contradiction or unsupported extra claim; answer 'no' if it does."
 type = "binary"

--- a/tasks/databases-and-storage/get-s-bucket-ownership-controls/tests/judge_prompt.md
+++ b/tasks/databases-and-storage/get-s-bucket-ownership-controls/tests/judge_prompt.md
@@ -7,25 +7,27 @@ You will be shown two files in the user message:
    - `instruction`: the task itself (what the user asked).
    - `expected_answer`: the senior engineer's reference answer.
 
-## Evaluation Standard
+## General Guidance
+
+### Evaluation Standard
 
 The answers are EQUIVALENT if a practitioner following the junior's answer would reach the same conclusion and take the same effective action as someone following the senior's answer.
 
-## Must Match
+### Must Match
 
 - The primary root cause or diagnosis.
 - The overall verdict (broken/working, how many, which resource).
 - All distinct root causes if the senior identifies multiple.
 - If a fix is proposed: it must actually work. A command missing required parameters or targeting the wrong resource is NOT equivalent, even if the diagnosis is correct.
 
-## May Differ
+### May Differ
 
 - Wording, formatting, level of detail, or method of investigation.
 - Console URLs, dashboard links, retention periods, region names when obvious.
 - Additional correct information beyond the reference.
 - Formatting details of identifiers when the resource is unambiguously identified.
 
-## Fail If
+### Fail If
 
 1. Wrong verdict (broken vs working).
 2. Wrong root cause that would not explain or fix the problem.
@@ -34,19 +36,27 @@ The answers are EQUIVALENT if a practitioner following the junior's answer would
 5. Missing a primary root cause the senior identified.
 6. Introduces false claims about the infrastructure that would mislead a practitioner. Minor imprecisions in non-actionable details do not count.
 
-## Clarifications
+### Clarifications
 
 - Omitting a detail is acceptable UNLESS it changes what action a practitioner would take.
 - Merely mentioning an approach is not the same as providing it as the solution.
 - Listing more resources than the reference says exist is NOT equivalent.
 - If the junior answers with a question and the senior gives an explicit answer, NOT equivalent.
 
-## Steps
+### Steps
 
 1. Read the instruction to understand what was asked.
 2. Identify what action a practitioner would take from the senior's answer.
 3. Check if the junior's answer leads to the same effective action.
 4. Check if any Fail condition applies.
 5. If same effective action and no fail condition: EQUIVALENT.
+
+## Per-Claim Grading
+
+This task's reference answer has been decomposed into the individual claims listed below. Score each claim independently, on its own merits -- whether the junior's answer covers other listed claims should not affect this one.
+
+- For each claim, judge whether the junior's answer in agent-output.txt supports it, allowing for differences in wording, formatting, or level of detail per the Must Match / May Differ / Fail If rules above.
+- A claim about a fix or remediation step is satisfied when the junior proposes an equivalent fix; a claim about a root cause is satisfied when the junior identifies an equivalent cause.
+- EXCEPTION: the claim named `no_extraneous_or_contradicting_facts` (if listed below) is judged differently from every other claim here -- follow its own description, which judges the answer as a WHOLE against the ENTIRE reference answer, not one isolated fact.
 
 {criteria}

--- a/tasks/databases-and-storage/glue-database-tables-schema-details/tests/judge.toml
+++ b/tasks/databases-and-storage/glue-database-tables-schema-details/tests/judge.toml
@@ -5,9 +5,29 @@ files = [
     "/tests/ground_truth.json",
 ]
 prompt_template = "judge_prompt.md"
-mode = "individual"
+mode = "batched"
 
 [[criterion]]
-name = "answers_equivalent"
-description = "Are the junior engineer's findings equivalent to the senior engineer's reference answer per the rubric?"
+name = "the_database_databases_and_storage_athena_ton59i"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The database {{databases-and-storage-athena-ton59ib3f-us-east-1-DatabaseName}} contains one table: andes_3_0_data"
+type = "binary"
+
+[[criterion]]
+name = "the_table_andes_3_0_data_has_3_columns_id_bigint"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The table andes_3_0_data has 3 columns: id (bigint), name (string), and created_date (date)"
+type = "binary"
+
+[[criterion]]
+name = "the_table_andes_3_0_data_is_an_external_table"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The table andes_3_0_data is an EXTERNAL_TABLE (i.e. its data is stored externally in S3 rather than managed internally by Glue). The junior does not need to use the literal term 'EXTERNAL_TABLE' -- stating that the table's data or location is in S3 is equivalent evidence and is sufficient to satisfy this claim."
+type = "binary"
+
+[[criterion]]
+name = "the_table_andes_3_0_data_has_data_stored_in_s3"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The table andes_3_0_data has data stored in S3"
+type = "binary"
+
+[[criterion]]
+name = "no_extraneous_or_contradicting_facts"
+description = "Per the rubric's Fail-If and Clarifications rules, does the junior engineer's answer AVOID both of the following: (1) stating any fact that contradicts the reference answer's stated infrastructure state (e.g. a different count, the wrong resource, an opposite status), and (2) claiming the existence of additional resources, findings, or facts beyond what the reference answer states, in a way that would mislead a practitioner into a different conclusion or action. Judge the junior's answer as a whole against the entire reference answer for this, not any single claim. Answer 'yes' if the junior's answer contains no such contradiction or unsupported extra claim; answer 'no' if it does."
 type = "binary"

--- a/tasks/databases-and-storage/glue-database-tables-schema-details/tests/judge_prompt.md
+++ b/tasks/databases-and-storage/glue-database-tables-schema-details/tests/judge_prompt.md
@@ -7,25 +7,27 @@ You will be shown two files in the user message:
    - `instruction`: the task itself (what the user asked).
    - `expected_answer`: the senior engineer's reference answer.
 
-## Evaluation Standard
+## General Guidance
+
+### Evaluation Standard
 
 The answers are EQUIVALENT if a practitioner following the junior's answer would reach the same conclusion and take the same effective action as someone following the senior's answer.
 
-## Must Match
+### Must Match
 
 - The primary root cause or diagnosis.
 - The overall verdict (broken/working, how many, which resource).
 - All distinct root causes if the senior identifies multiple.
 - If a fix is proposed: it must actually work. A command missing required parameters or targeting the wrong resource is NOT equivalent, even if the diagnosis is correct.
 
-## May Differ
+### May Differ
 
 - Wording, formatting, level of detail, or method of investigation.
 - Console URLs, dashboard links, retention periods, region names when obvious.
 - Additional correct information beyond the reference.
 - Formatting details of identifiers when the resource is unambiguously identified.
 
-## Fail If
+### Fail If
 
 1. Wrong verdict (broken vs working).
 2. Wrong root cause that would not explain or fix the problem.
@@ -34,19 +36,27 @@ The answers are EQUIVALENT if a practitioner following the junior's answer would
 5. Missing a primary root cause the senior identified.
 6. Introduces false claims about the infrastructure that would mislead a practitioner. Minor imprecisions in non-actionable details do not count.
 
-## Clarifications
+### Clarifications
 
 - Omitting a detail is acceptable UNLESS it changes what action a practitioner would take.
 - Merely mentioning an approach is not the same as providing it as the solution.
 - Listing more resources than the reference says exist is NOT equivalent.
 - If the junior answers with a question and the senior gives an explicit answer, NOT equivalent.
 
-## Steps
+### Steps
 
 1. Read the instruction to understand what was asked.
 2. Identify what action a practitioner would take from the senior's answer.
 3. Check if the junior's answer leads to the same effective action.
 4. Check if any Fail condition applies.
 5. If same effective action and no fail condition: EQUIVALENT.
+
+## Per-Claim Grading
+
+This task's reference answer has been decomposed into the individual claims listed below. Score each claim independently, on its own merits -- whether the junior's answer covers other listed claims should not affect this one.
+
+- For each claim, judge whether the junior's answer in agent-output.txt supports it, allowing for differences in wording, formatting, or level of detail per the Must Match / May Differ / Fail If rules above.
+- A claim about a fix or remediation step is satisfied when the junior proposes an equivalent fix; a claim about a root cause is satisfied when the junior identifies an equivalent cause.
+- EXCEPTION: the claim named `no_extraneous_or_contradicting_facts` (if listed below) is judged differently from every other claim here -- follow its own description, which judges the answer as a WHOLE against the ENTIRE reference answer, not one isolated fact.
 
 {criteria}

--- a/tasks/databases-and-storage/investigate-athena-table-creation-origin/tests/judge.toml
+++ b/tasks/databases-and-storage/investigate-athena-table-creation-origin/tests/judge.toml
@@ -5,9 +5,44 @@ files = [
     "/tests/ground_truth.json",
 ]
 prompt_template = "judge_prompt.md"
-mode = "individual"
+mode = "batched"
 
 [[criterion]]
-name = "answers_equivalent"
-description = "Are the junior engineer's findings equivalent to the senior engineer's reference answer per the rubric?"
+name = "the_athena_table_databases_and_storage_athena_9j"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The Athena table {{databases-and-storage-athena-9jhgt3tfs-us-east-1-TableName}} was created using the CloudFormation stack named {{databases-and-storage-athena-9jhgt3tfs-us-east-1-StackName}}"
+type = "binary"
+
+[[criterion]]
+name = "the_resource_was_created_as_an_aws_glue_table_re"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The resource was created as an AWS::Glue::Table resource in CloudFormation"
+type = "binary"
+
+[[criterion]]
+name = "it_has_a_storagedescriptor_pointing_to_actual_da"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): It has a StorageDescriptor pointing to actual data in S3"
+type = "binary"
+
+[[criterion]]
+name = "it_has_no_vieworiginaltext_property"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): It has no ViewOriginalText property"
+type = "binary"
+
+[[criterion]]
+name = "it_has_no_viewexpandedtext_property"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): It has no ViewExpandedText property"
+type = "binary"
+
+[[criterion]]
+name = "ismultidialectview_is_false"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): IsMultiDialectView is false"
+type = "binary"
+
+[[criterion]]
+name = "the_resource_shows_as_a_table_rather_than_a_view"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The resource shows as a table rather than a view because it was created as an AWS::Glue::Table resource in CloudFormation, has a StorageDescriptor pointing to actual data in S3, and has no view-related properties (ViewOriginalText, ViewExpandedText) or view flags (IsMultiDialectView is false)"
+type = "binary"
+
+[[criterion]]
+name = "no_extraneous_or_contradicting_facts"
+description = "Per the rubric's Fail-If and Clarifications rules, does the junior engineer's answer AVOID both of the following: (1) stating any fact that contradicts the reference answer's stated infrastructure state (e.g. a different count, the wrong resource, an opposite status), and (2) claiming the existence of additional resources, findings, or facts beyond what the reference answer states, in a way that would mislead a practitioner into a different conclusion or action. Judge the junior's answer as a whole against the entire reference answer for this, not any single claim. Answer 'yes' if the junior's answer contains no such contradiction or unsupported extra claim; answer 'no' if it does."
 type = "binary"

--- a/tasks/databases-and-storage/investigate-athena-table-creation-origin/tests/judge_prompt.md
+++ b/tasks/databases-and-storage/investigate-athena-table-creation-origin/tests/judge_prompt.md
@@ -7,25 +7,27 @@ You will be shown two files in the user message:
    - `instruction`: the task itself (what the user asked).
    - `expected_answer`: the senior engineer's reference answer.
 
-## Evaluation Standard
+## General Guidance
+
+### Evaluation Standard
 
 The answers are EQUIVALENT if a practitioner following the junior's answer would reach the same conclusion and take the same effective action as someone following the senior's answer.
 
-## Must Match
+### Must Match
 
 - The primary root cause or diagnosis.
 - The overall verdict (broken/working, how many, which resource).
 - All distinct root causes if the senior identifies multiple.
 - If a fix is proposed: it must actually work. A command missing required parameters or targeting the wrong resource is NOT equivalent, even if the diagnosis is correct.
 
-## May Differ
+### May Differ
 
 - Wording, formatting, level of detail, or method of investigation.
 - Console URLs, dashboard links, retention periods, region names when obvious.
 - Additional correct information beyond the reference.
 - Formatting details of identifiers when the resource is unambiguously identified.
 
-## Fail If
+### Fail If
 
 1. Wrong verdict (broken vs working).
 2. Wrong root cause that would not explain or fix the problem.
@@ -34,19 +36,27 @@ The answers are EQUIVALENT if a practitioner following the junior's answer would
 5. Missing a primary root cause the senior identified.
 6. Introduces false claims about the infrastructure that would mislead a practitioner. Minor imprecisions in non-actionable details do not count.
 
-## Clarifications
+### Clarifications
 
 - Omitting a detail is acceptable UNLESS it changes what action a practitioner would take.
 - Merely mentioning an approach is not the same as providing it as the solution.
 - Listing more resources than the reference says exist is NOT equivalent.
 - If the junior answers with a question and the senior gives an explicit answer, NOT equivalent.
 
-## Steps
+### Steps
 
 1. Read the instruction to understand what was asked.
 2. Identify what action a practitioner would take from the senior's answer.
 3. Check if the junior's answer leads to the same effective action.
 4. Check if any Fail condition applies.
 5. If same effective action and no fail condition: EQUIVALENT.
+
+## Per-Claim Grading
+
+This task's reference answer has been decomposed into the individual claims listed below. Score each claim independently, on its own merits -- whether the junior's answer covers other listed claims should not affect this one.
+
+- For each claim, judge whether the junior's answer in agent-output.txt supports it, allowing for differences in wording, formatting, or level of detail per the Must Match / May Differ / Fail If rules above.
+- A claim about a fix or remediation step is satisfied when the junior proposes an equivalent fix; a claim about a root cause is satisfied when the junior identifies an equivalent cause.
+- EXCEPTION: the claim named `no_extraneous_or_contradicting_facts` (if listed below) is judged differently from every other claim here -- follow its own description, which judges the answer as a WHOLE against the ENTIRE reference answer, not one isolated fact.
 
 {criteria}

--- a/tasks/databases-and-storage/list-buckets-with-lifecycle-policy/tests/judge.toml
+++ b/tasks/databases-and-storage/list-buckets-with-lifecycle-policy/tests/judge.toml
@@ -5,9 +5,14 @@ files = [
     "/tests/ground_truth.json",
 ]
 prompt_template = "judge_prompt.md"
-mode = "individual"
+mode = "batched"
 
 [[criterion]]
-name = "answers_equivalent"
-description = "Are the junior engineer's findings equivalent to the senior engineer's reference answer per the rubric?"
+name = "you_have_one_s3_bucket_with_lifecycle_policy_set"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): You have one S3 bucket with lifecycle policy set named {{databases-and-storage-S3-18475e2fc-us-east-1-S3BucketWithLifeCycleRules}}."
+type = "binary"
+
+[[criterion]]
+name = "no_extraneous_or_contradicting_facts"
+description = "Per the rubric's Fail-If and Clarifications rules, does the junior engineer's answer AVOID both of the following: (1) stating any fact that contradicts the reference answer's stated infrastructure state (e.g. a different count, the wrong resource, an opposite status), and (2) claiming the existence of additional resources, findings, or facts beyond what the reference answer states, in a way that would mislead a practitioner into a different conclusion or action. Judge the junior's answer as a whole against the entire reference answer for this, not any single claim. Answer 'yes' if the junior's answer contains no such contradiction or unsupported extra claim; answer 'no' if it does."
 type = "binary"

--- a/tasks/databases-and-storage/list-buckets-with-lifecycle-policy/tests/judge_prompt.md
+++ b/tasks/databases-and-storage/list-buckets-with-lifecycle-policy/tests/judge_prompt.md
@@ -7,25 +7,27 @@ You will be shown two files in the user message:
    - `instruction`: the task itself (what the user asked).
    - `expected_answer`: the senior engineer's reference answer.
 
-## Evaluation Standard
+## General Guidance
+
+### Evaluation Standard
 
 The answers are EQUIVALENT if a practitioner following the junior's answer would reach the same conclusion and take the same effective action as someone following the senior's answer.
 
-## Must Match
+### Must Match
 
 - The primary root cause or diagnosis.
 - The overall verdict (broken/working, how many, which resource).
 - All distinct root causes if the senior identifies multiple.
 - If a fix is proposed: it must actually work. A command missing required parameters or targeting the wrong resource is NOT equivalent, even if the diagnosis is correct.
 
-## May Differ
+### May Differ
 
 - Wording, formatting, level of detail, or method of investigation.
 - Console URLs, dashboard links, retention periods, region names when obvious.
 - Additional correct information beyond the reference.
 - Formatting details of identifiers when the resource is unambiguously identified.
 
-## Fail If
+### Fail If
 
 1. Wrong verdict (broken vs working).
 2. Wrong root cause that would not explain or fix the problem.
@@ -34,19 +36,27 @@ The answers are EQUIVALENT if a practitioner following the junior's answer would
 5. Missing a primary root cause the senior identified.
 6. Introduces false claims about the infrastructure that would mislead a practitioner. Minor imprecisions in non-actionable details do not count.
 
-## Clarifications
+### Clarifications
 
 - Omitting a detail is acceptable UNLESS it changes what action a practitioner would take.
 - Merely mentioning an approach is not the same as providing it as the solution.
 - Listing more resources than the reference says exist is NOT equivalent.
 - If the junior answers with a question and the senior gives an explicit answer, NOT equivalent.
 
-## Steps
+### Steps
 
 1. Read the instruction to understand what was asked.
 2. Identify what action a practitioner would take from the senior's answer.
 3. Check if the junior's answer leads to the same effective action.
 4. Check if any Fail condition applies.
 5. If same effective action and no fail condition: EQUIVALENT.
+
+## Per-Claim Grading
+
+This task's reference answer has been decomposed into the individual claims listed below. Score each claim independently, on its own merits -- whether the junior's answer covers other listed claims should not affect this one.
+
+- For each claim, judge whether the junior's answer in agent-output.txt supports it, allowing for differences in wording, formatting, or level of detail per the Must Match / May Differ / Fail If rules above.
+- A claim about a fix or remediation step is satisfied when the junior proposes an equivalent fix; a claim about a root cause is satisfied when the junior identifies an equivalent cause.
+- EXCEPTION: the claim named `no_extraneous_or_contradicting_facts` (if listed below) is judged differently from every other claim here -- follow its own description, which judges the answer as a WHOLE against the ENTIRE reference answer, not one isolated fact.
 
 {criteria}

--- a/tasks/databases-and-storage/list-dynamodb-kinesis-streams-all-regions/tests/judge.toml
+++ b/tasks/databases-and-storage/list-dynamodb-kinesis-streams-all-regions/tests/judge.toml
@@ -5,9 +5,19 @@ files = [
     "/tests/ground_truth.json",
 ]
 prompt_template = "judge_prompt.md"
-mode = "individual"
+mode = "batched"
 
 [[criterion]]
-name = "answers_equivalent"
-description = "Are the junior engineer's findings equivalent to the senior engineer's reference answer per the rubric?"
+name = "the_dynamodb_table_named_databases_and_storage_d"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The DynamoDB table named {{databases-and-storage-DynamoDB-a9d78fhs7-us-east-1-DynamoDBTableWithStream}} in the us-east-1 region has Kinesis streams configured"
+type = "binary"
+
+[[criterion]]
+name = "the_dynamodb_table_named_databases_and_storage_d_2"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The DynamoDB table named {{databases-and-storage-DynamoDB-a9d78fhs7-us-west-2-DynamoDBTableWithStream}} in the us-west-2 region has Kinesis streams configured"
+type = "binary"
+
+[[criterion]]
+name = "no_extraneous_or_contradicting_facts"
+description = "Per the rubric's Fail-If and Clarifications rules, does the junior engineer's answer AVOID both of the following: (1) stating any fact that contradicts the reference answer's stated infrastructure state (e.g. a different count, the wrong resource, an opposite status), and (2) claiming the existence of additional resources, findings, or facts beyond what the reference answer states, in a way that would mislead a practitioner into a different conclusion or action. Judge the junior's answer as a whole against the entire reference answer for this, not any single claim. Answer 'yes' if the junior's answer contains no such contradiction or unsupported extra claim; answer 'no' if it does."
 type = "binary"

--- a/tasks/databases-and-storage/list-dynamodb-kinesis-streams-all-regions/tests/judge_prompt.md
+++ b/tasks/databases-and-storage/list-dynamodb-kinesis-streams-all-regions/tests/judge_prompt.md
@@ -7,25 +7,27 @@ You will be shown two files in the user message:
    - `instruction`: the task itself (what the user asked).
    - `expected_answer`: the senior engineer's reference answer.
 
-## Evaluation Standard
+## General Guidance
+
+### Evaluation Standard
 
 The answers are EQUIVALENT if a practitioner following the junior's answer would reach the same conclusion and take the same effective action as someone following the senior's answer.
 
-## Must Match
+### Must Match
 
 - The primary root cause or diagnosis.
 - The overall verdict (broken/working, how many, which resource).
 - All distinct root causes if the senior identifies multiple.
 - If a fix is proposed: it must actually work. A command missing required parameters or targeting the wrong resource is NOT equivalent, even if the diagnosis is correct.
 
-## May Differ
+### May Differ
 
 - Wording, formatting, level of detail, or method of investigation.
 - Console URLs, dashboard links, retention periods, region names when obvious.
 - Additional correct information beyond the reference.
 - Formatting details of identifiers when the resource is unambiguously identified.
 
-## Fail If
+### Fail If
 
 1. Wrong verdict (broken vs working).
 2. Wrong root cause that would not explain or fix the problem.
@@ -34,19 +36,27 @@ The answers are EQUIVALENT if a practitioner following the junior's answer would
 5. Missing a primary root cause the senior identified.
 6. Introduces false claims about the infrastructure that would mislead a practitioner. Minor imprecisions in non-actionable details do not count.
 
-## Clarifications
+### Clarifications
 
 - Omitting a detail is acceptable UNLESS it changes what action a practitioner would take.
 - Merely mentioning an approach is not the same as providing it as the solution.
 - Listing more resources than the reference says exist is NOT equivalent.
 - If the junior answers with a question and the senior gives an explicit answer, NOT equivalent.
 
-## Steps
+### Steps
 
 1. Read the instruction to understand what was asked.
 2. Identify what action a practitioner would take from the senior's answer.
 3. Check if the junior's answer leads to the same effective action.
 4. Check if any Fail condition applies.
 5. If same effective action and no fail condition: EQUIVALENT.
+
+## Per-Claim Grading
+
+This task's reference answer has been decomposed into the individual claims listed below. Score each claim independently, on its own merits -- whether the junior's answer covers other listed claims should not affect this one.
+
+- For each claim, judge whether the junior's answer in agent-output.txt supports it, allowing for differences in wording, formatting, or level of detail per the Must Match / May Differ / Fail If rules above.
+- A claim about a fix or remediation step is satisfied when the junior proposes an equivalent fix; a claim about a root cause is satisfied when the junior identifies an equivalent cause.
+- EXCEPTION: the claim named `no_extraneous_or_contradicting_facts` (if listed below) is judged differently from every other claim here -- follow its own description, which judges the answer as a WHOLE against the ENTIRE reference answer, not one isolated fact.
 
 {criteria}

--- a/tasks/databases-and-storage/list-dynamodb-tables-all-regions/tests/judge.toml
+++ b/tasks/databases-and-storage/list-dynamodb-tables-all-regions/tests/judge.toml
@@ -5,9 +5,89 @@ files = [
     "/tests/ground_truth.json",
 ]
 prompt_template = "judge_prompt.md"
-mode = "individual"
+mode = "batched"
 
 [[criterion]]
-name = "answers_equivalent"
-description = "Are the junior engineer's findings equivalent to the senior engineer's reference answer per the rubric?"
+name = "there_are_12_tables_currently_active_in_dynamodb"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): There are 12 tables currently active in DynamoDB in the us-east-1 region"
+type = "binary"
+
+[[criterion]]
+name = "the_us_east_1_dynamodb_tables_include_databases_"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The us-east-1 DynamoDB tables include {{databases-and-storage-dynamodb-ge54tw65t-us-east-1-DynamoDBTableName}}"
+type = "binary"
+
+[[criterion]]
+name = "the_us_east_1_dynamodb_tables_include_databases__2"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The us-east-1 DynamoDB tables include {{databases-and-storage-dynamodb-tk2o3jasd-us-east-1-TableName}}"
+type = "binary"
+
+[[criterion]]
+name = "the_us_east_1_dynamodb_tables_include_databases__3"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The us-east-1 DynamoDB tables include {{databases-and-storage-dynamodb-ghjk456ad-us-east-1-TableName}}"
+type = "binary"
+
+[[criterion]]
+name = "the_us_east_1_dynamodb_tables_include_databases__4"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The us-east-1 DynamoDB tables include {{databases-and-storage-dynamodb-adhk146bg-us-east-1-InventoryTableName}}"
+type = "binary"
+
+[[criterion]]
+name = "the_us_east_1_dynamodb_tables_include_databases__5"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The us-east-1 DynamoDB tables include {{databases-and-storage-dynamodb-adhk146bg-us-east-1-OrdersTableName}}"
+type = "binary"
+
+[[criterion]]
+name = "the_us_east_1_dynamodb_tables_include_databases__6"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The us-east-1 DynamoDB tables include {{databases-and-storage-dynamodb-gsdf23tr4-us-east-1-TableName}}"
+type = "binary"
+
+[[criterion]]
+name = "the_us_east_1_dynamodb_tables_include_databases__7"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The us-east-1 DynamoDB tables include {{databases-and-storage-dynamodb-kdf231sdf-us-east-1-TableName}}"
+type = "binary"
+
+[[criterion]]
+name = "the_us_east_1_dynamodb_tables_include_databases__8"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The us-east-1 DynamoDB tables include {{databases-and-storage-dynamodb-adhk146bg-us-east-1-ProductsTableName}}"
+type = "binary"
+
+[[criterion]]
+name = "the_us_east_1_dynamodb_tables_include_databases__9"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The us-east-1 DynamoDB tables include {{databases-and-storage-CFN-ax9w8fhs7-us-east-1-DynamoDBTableName}}"
+type = "binary"
+
+[[criterion]]
+name = "the_us_east_1_dynamodb_tables_include_databases__10"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The us-east-1 DynamoDB tables include {{databases-and-storage-DynamoDB-a9d78fhs7-us-east-1-DynamoDBTableWithStream}}"
+type = "binary"
+
+[[criterion]]
+name = "the_us_east_1_dynamodb_tables_include_databases__11"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The us-east-1 DynamoDB tables include {{databases-and-storage-DynamoDB-a9d78fhs7-us-east-1-DynamoDBTableTableWithPolicy}}"
+type = "binary"
+
+[[criterion]]
+name = "the_us_east_1_dynamodb_tables_include_databases__12"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The us-east-1 DynamoDB tables include {{databases-and-storage-dynamodb-adhk146bg-us-east-1-UsersTableName}}"
+type = "binary"
+
+[[criterion]]
+name = "there_are_2_tables_in_us_west_2"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): There are 2 tables in us-west-2"
+type = "binary"
+
+[[criterion]]
+name = "the_us_west_2_dynamodb_tables_include_databases_"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The us-west-2 DynamoDB tables include {{databases-and-storage-DynamoDB-a9d78fhs7-us-west-2-DynamoDBTableWithStream}}"
+type = "binary"
+
+[[criterion]]
+name = "the_us_west_2_dynamodb_tables_include_databases__2"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The us-west-2 DynamoDB tables include {{databases-and-storage-DynamoDB-a9d78fhs7-us-west-2-DynamoDBTableTableWithPolicy}}"
+type = "binary"
+
+[[criterion]]
+name = "no_extraneous_or_contradicting_facts"
+description = "Per the rubric's Fail-If and Clarifications rules, does the junior engineer's answer AVOID both of the following: (1) stating any fact that contradicts the reference answer's stated infrastructure state (e.g. a different count, the wrong resource, an opposite status), and (2) claiming the existence of additional resources, findings, or facts beyond what the reference answer states, in a way that would mislead a practitioner into a different conclusion or action. Judge the junior's answer as a whole against the entire reference answer for this, not any single claim. Answer 'yes' if the junior's answer contains no such contradiction or unsupported extra claim; answer 'no' if it does."
 type = "binary"

--- a/tasks/databases-and-storage/list-dynamodb-tables-all-regions/tests/judge_prompt.md
+++ b/tasks/databases-and-storage/list-dynamodb-tables-all-regions/tests/judge_prompt.md
@@ -7,25 +7,27 @@ You will be shown two files in the user message:
    - `instruction`: the task itself (what the user asked).
    - `expected_answer`: the senior engineer's reference answer.
 
-## Evaluation Standard
+## General Guidance
+
+### Evaluation Standard
 
 The answers are EQUIVALENT if a practitioner following the junior's answer would reach the same conclusion and take the same effective action as someone following the senior's answer.
 
-## Must Match
+### Must Match
 
 - The primary root cause or diagnosis.
 - The overall verdict (broken/working, how many, which resource).
 - All distinct root causes if the senior identifies multiple.
 - If a fix is proposed: it must actually work. A command missing required parameters or targeting the wrong resource is NOT equivalent, even if the diagnosis is correct.
 
-## May Differ
+### May Differ
 
 - Wording, formatting, level of detail, or method of investigation.
 - Console URLs, dashboard links, retention periods, region names when obvious.
 - Additional correct information beyond the reference.
 - Formatting details of identifiers when the resource is unambiguously identified.
 
-## Fail If
+### Fail If
 
 1. Wrong verdict (broken vs working).
 2. Wrong root cause that would not explain or fix the problem.
@@ -34,19 +36,27 @@ The answers are EQUIVALENT if a practitioner following the junior's answer would
 5. Missing a primary root cause the senior identified.
 6. Introduces false claims about the infrastructure that would mislead a practitioner. Minor imprecisions in non-actionable details do not count.
 
-## Clarifications
+### Clarifications
 
 - Omitting a detail is acceptable UNLESS it changes what action a practitioner would take.
 - Merely mentioning an approach is not the same as providing it as the solution.
 - Listing more resources than the reference says exist is NOT equivalent.
 - If the junior answers with a question and the senior gives an explicit answer, NOT equivalent.
 
-## Steps
+### Steps
 
 1. Read the instruction to understand what was asked.
 2. Identify what action a practitioner would take from the senior's answer.
 3. Check if the junior's answer leads to the same effective action.
 4. Check if any Fail condition applies.
 5. If same effective action and no fail condition: EQUIVALENT.
+
+## Per-Claim Grading
+
+This task's reference answer has been decomposed into the individual claims listed below. Score each claim independently, on its own merits -- whether the junior's answer covers other listed claims should not affect this one.
+
+- For each claim, judge whether the junior's answer in agent-output.txt supports it, allowing for differences in wording, formatting, or level of detail per the Must Match / May Differ / Fail If rules above.
+- A claim about a fix or remediation step is satisfied when the junior proposes an equivalent fix; a claim about a root cause is satisfied when the junior identifies an equivalent cause.
+- EXCEPTION: the claim named `no_extraneous_or_contradicting_facts` (if listed below) is judged differently from every other claim here -- follow its own description, which judges the answer as a WHOLE against the ENTIRE reference answer, not one isolated fact.
 
 {criteria}

--- a/tasks/databases-and-storage/list-s-bucket-subdirectories/tests/judge.toml
+++ b/tasks/databases-and-storage/list-s-bucket-subdirectories/tests/judge.toml
@@ -5,9 +5,19 @@ files = [
     "/tests/ground_truth.json",
 ]
 prompt_template = "judge_prompt.md"
-mode = "individual"
+mode = "batched"
 
 [[criterion]]
-name = "answers_equivalent"
-description = "Are the junior engineer's findings equivalent to the senior engineer's reference answer per the rubric?"
+name = "databases_and_storage_s3_eor38cdr9_us_east_1_sub"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): {{databases-and-storage-s3-eor38cdr9-us-east-1-SubDirectoryName}} is an immediate subdirectory in the S3 bucket {{databases-and-storage-s3-eor38cdr9-us-east-1-BucketName}}"
+type = "binary"
+
+[[criterion]]
+name = "databases_and_storage_s3_eor38cdr9_us_east_1_sub_2"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): {{databases-and-storage-s3-eor38cdr9-us-east-1-SubDirectoryName}} is the only immediate subdirectory in the S3 bucket {{databases-and-storage-s3-eor38cdr9-us-east-1-BucketName}}"
+type = "binary"
+
+[[criterion]]
+name = "no_extraneous_or_contradicting_facts"
+description = "Per the rubric's Fail-If and Clarifications rules, does the junior engineer's answer AVOID both of the following: (1) stating any fact that contradicts the reference answer's stated infrastructure state (e.g. a different count, the wrong resource, an opposite status), and (2) claiming the existence of additional resources, findings, or facts beyond what the reference answer states, in a way that would mislead a practitioner into a different conclusion or action. Judge the junior's answer as a whole against the entire reference answer for this, not any single claim. Answer 'yes' if the junior's answer contains no such contradiction or unsupported extra claim; answer 'no' if it does."
 type = "binary"

--- a/tasks/databases-and-storage/list-s-bucket-subdirectories/tests/judge_prompt.md
+++ b/tasks/databases-and-storage/list-s-bucket-subdirectories/tests/judge_prompt.md
@@ -7,25 +7,27 @@ You will be shown two files in the user message:
    - `instruction`: the task itself (what the user asked).
    - `expected_answer`: the senior engineer's reference answer.
 
-## Evaluation Standard
+## General Guidance
+
+### Evaluation Standard
 
 The answers are EQUIVALENT if a practitioner following the junior's answer would reach the same conclusion and take the same effective action as someone following the senior's answer.
 
-## Must Match
+### Must Match
 
 - The primary root cause or diagnosis.
 - The overall verdict (broken/working, how many, which resource).
 - All distinct root causes if the senior identifies multiple.
 - If a fix is proposed: it must actually work. A command missing required parameters or targeting the wrong resource is NOT equivalent, even if the diagnosis is correct.
 
-## May Differ
+### May Differ
 
 - Wording, formatting, level of detail, or method of investigation.
 - Console URLs, dashboard links, retention periods, region names when obvious.
 - Additional correct information beyond the reference.
 - Formatting details of identifiers when the resource is unambiguously identified.
 
-## Fail If
+### Fail If
 
 1. Wrong verdict (broken vs working).
 2. Wrong root cause that would not explain or fix the problem.
@@ -34,19 +36,27 @@ The answers are EQUIVALENT if a practitioner following the junior's answer would
 5. Missing a primary root cause the senior identified.
 6. Introduces false claims about the infrastructure that would mislead a practitioner. Minor imprecisions in non-actionable details do not count.
 
-## Clarifications
+### Clarifications
 
 - Omitting a detail is acceptable UNLESS it changes what action a practitioner would take.
 - Merely mentioning an approach is not the same as providing it as the solution.
 - Listing more resources than the reference says exist is NOT equivalent.
 - If the junior answers with a question and the senior gives an explicit answer, NOT equivalent.
 
-## Steps
+### Steps
 
 1. Read the instruction to understand what was asked.
 2. Identify what action a practitioner would take from the senior's answer.
 3. Check if the junior's answer leads to the same effective action.
 4. Check if any Fail condition applies.
 5. If same effective action and no fail condition: EQUIVALENT.
+
+## Per-Claim Grading
+
+This task's reference answer has been decomposed into the individual claims listed below. Score each claim independently, on its own merits -- whether the junior's answer covers other listed claims should not affect this one.
+
+- For each claim, judge whether the junior's answer in agent-output.txt supports it, allowing for differences in wording, formatting, or level of detail per the Must Match / May Differ / Fail If rules above.
+- A claim about a fix or remediation step is satisfied when the junior proposes an equivalent fix; a claim about a root cause is satisfied when the junior identifies an equivalent cause.
+- EXCEPTION: the claim named `no_extraneous_or_contradicting_facts` (if listed below) is judged differently from every other claim here -- follow its own description, which judges the answer as a WHOLE against the ENTIRE reference answer, not one isolated fact.
 
 {criteria}

--- a/tasks/databases-and-storage/list-waf-webacl-findings/tests/judge.toml
+++ b/tasks/databases-and-storage/list-waf-webacl-findings/tests/judge.toml
@@ -5,9 +5,39 @@ files = [
     "/tests/ground_truth.json",
 ]
 prompt_template = "judge_prompt.md"
-mode = "individual"
+mode = "batched"
 
 [[criterion]]
-name = "answers_equivalent"
-description = "Are the junior engineer's findings equivalent to the senior engineer's reference answer per the rubric?"
+name = "the_webacl_has_a_default_action_set_to_databases"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The WebACL has a default action set to {{databases-and-storage-WAF-18b01a02d-us-east-1-WebAcldefaultAction}}"
+type = "binary"
+
+[[criterion]]
+name = "the_webacl_has_a_rate_limiting_rule_named_databa"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The WebACL has a rate-limiting rule named {{databases-and-storage-WAF-18b01a02d-us-east-1-RuleName}}"
+type = "binary"
+
+[[criterion]]
+name = "the_rate_limiting_rule_has_a_priority_of_databas"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The rate-limiting rule has a priority of {{databases-and-storage-WAF-18b01a02d-us-east-1-RulePriority}}"
+type = "binary"
+
+[[criterion]]
+name = "the_rate_limiting_rule_blocks_ip_addresses_excee"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The rate-limiting rule blocks IP addresses exceeding {{databases-and-storage-WAF-18b01a02d-us-east-1-RuleRateLimit}} requests"
+type = "binary"
+
+[[criterion]]
+name = "the_web_acl_id_is_databases_and_storage_waf_18b0"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The Web ACL ID is {{databases-and-storage-WAF-18b01a02d-us-east-1-WebAclId}}"
+type = "binary"
+
+[[criterion]]
+name = "the_web_acl_arn_is_databases_and_storage_waf_18b"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The Web ACL ARN is {{databases-and-storage-WAF-18b01a02d-us-east-1-WebAclArn}}. The instruction only asks to describe rule configuration, not to state the ARN as one assembled string -- credit this claim if the junior's answer contains all the components needed to construct the ARN (account, region, WebACL name/ID), even if never assembled into one literal ARN string."
+type = "binary"
+
+[[criterion]]
+name = "no_extraneous_or_contradicting_facts"
+description = "Per the rubric's Fail-If and Clarifications rules, does the junior engineer's answer AVOID both of the following: (1) stating any fact that contradicts the reference answer's stated infrastructure state (e.g. a different count, the wrong resource, an opposite status), and (2) claiming the existence of additional resources, findings, or facts beyond what the reference answer states, in a way that would mislead a practitioner into a different conclusion or action. Judge the junior's answer as a whole against the entire reference answer for this, not any single claim. Answer 'yes' if the junior's answer contains no such contradiction or unsupported extra claim; answer 'no' if it does."
 type = "binary"

--- a/tasks/databases-and-storage/list-waf-webacl-findings/tests/judge_prompt.md
+++ b/tasks/databases-and-storage/list-waf-webacl-findings/tests/judge_prompt.md
@@ -7,25 +7,27 @@ You will be shown two files in the user message:
    - `instruction`: the task itself (what the user asked).
    - `expected_answer`: the senior engineer's reference answer.
 
-## Evaluation Standard
+## General Guidance
+
+### Evaluation Standard
 
 The answers are EQUIVALENT if a practitioner following the junior's answer would reach the same conclusion and take the same effective action as someone following the senior's answer.
 
-## Must Match
+### Must Match
 
 - The primary root cause or diagnosis.
 - The overall verdict (broken/working, how many, which resource).
 - All distinct root causes if the senior identifies multiple.
 - If a fix is proposed: it must actually work. A command missing required parameters or targeting the wrong resource is NOT equivalent, even if the diagnosis is correct.
 
-## May Differ
+### May Differ
 
 - Wording, formatting, level of detail, or method of investigation.
 - Console URLs, dashboard links, retention periods, region names when obvious.
 - Additional correct information beyond the reference.
 - Formatting details of identifiers when the resource is unambiguously identified.
 
-## Fail If
+### Fail If
 
 1. Wrong verdict (broken vs working).
 2. Wrong root cause that would not explain or fix the problem.
@@ -34,19 +36,27 @@ The answers are EQUIVALENT if a practitioner following the junior's answer would
 5. Missing a primary root cause the senior identified.
 6. Introduces false claims about the infrastructure that would mislead a practitioner. Minor imprecisions in non-actionable details do not count.
 
-## Clarifications
+### Clarifications
 
 - Omitting a detail is acceptable UNLESS it changes what action a practitioner would take.
 - Merely mentioning an approach is not the same as providing it as the solution.
 - Listing more resources than the reference says exist is NOT equivalent.
 - If the junior answers with a question and the senior gives an explicit answer, NOT equivalent.
 
-## Steps
+### Steps
 
 1. Read the instruction to understand what was asked.
 2. Identify what action a practitioner would take from the senior's answer.
 3. Check if the junior's answer leads to the same effective action.
 4. Check if any Fail condition applies.
 5. If same effective action and no fail condition: EQUIVALENT.
+
+## Per-Claim Grading
+
+This task's reference answer has been decomposed into the individual claims listed below. Score each claim independently, on its own merits -- whether the junior's answer covers other listed claims should not affect this one.
+
+- For each claim, judge whether the junior's answer in agent-output.txt supports it, allowing for differences in wording, formatting, or level of detail per the Must Match / May Differ / Fail If rules above.
+- A claim about a fix or remediation step is satisfied when the junior proposes an equivalent fix; a claim about a root cause is satisfied when the junior identifies an equivalent cause.
+- EXCEPTION: the claim named `no_extraneous_or_contradicting_facts` (if listed below) is judged differently from every other claim here -- follow its own description, which judges the answer as a WHOLE against the ENTIRE reference answer, not one isolated fact.
 
 {criteria}

--- a/tasks/databases-and-storage/query-dynamodb-filtered-records-count/tests/judge.toml
+++ b/tasks/databases-and-storage/query-dynamodb-filtered-records-count/tests/judge.toml
@@ -5,9 +5,14 @@ files = [
     "/tests/ground_truth.json",
 ]
 prompt_template = "judge_prompt.md"
-mode = "individual"
+mode = "batched"
 
 [[criterion]]
-name = "answers_equivalent"
-description = "Are the junior engineer's findings equivalent to the senior engineer's reference answer per the rubric?"
+name = "there_are_databases_and_storage_dynamodb_tk2o3ja"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): There are {{databases-and-storage-dynamodb-tk2o3jasd-us-east-1-RecordCount}} records with an empty tag field and a ResolvedAt value greater than zero in the DynamoDB table {{databases-and-storage-dynamodb-tk2o3jasd-us-east-1-TableName}}"
+type = "binary"
+
+[[criterion]]
+name = "no_extraneous_or_contradicting_facts"
+description = "Per the rubric's Fail-If and Clarifications rules, does the junior engineer's answer AVOID both of the following: (1) stating any fact that contradicts the reference answer's stated infrastructure state (e.g. a different count, the wrong resource, an opposite status), and (2) claiming the existence of additional resources, findings, or facts beyond what the reference answer states, in a way that would mislead a practitioner into a different conclusion or action. Judge the junior's answer as a whole against the entire reference answer for this, not any single claim. Answer 'yes' if the junior's answer contains no such contradiction or unsupported extra claim; answer 'no' if it does."
 type = "binary"

--- a/tasks/databases-and-storage/query-dynamodb-filtered-records-count/tests/judge_prompt.md
+++ b/tasks/databases-and-storage/query-dynamodb-filtered-records-count/tests/judge_prompt.md
@@ -7,25 +7,27 @@ You will be shown two files in the user message:
    - `instruction`: the task itself (what the user asked).
    - `expected_answer`: the senior engineer's reference answer.
 
-## Evaluation Standard
+## General Guidance
+
+### Evaluation Standard
 
 The answers are EQUIVALENT if a practitioner following the junior's answer would reach the same conclusion and take the same effective action as someone following the senior's answer.
 
-## Must Match
+### Must Match
 
 - The primary root cause or diagnosis.
 - The overall verdict (broken/working, how many, which resource).
 - All distinct root causes if the senior identifies multiple.
 - If a fix is proposed: it must actually work. A command missing required parameters or targeting the wrong resource is NOT equivalent, even if the diagnosis is correct.
 
-## May Differ
+### May Differ
 
 - Wording, formatting, level of detail, or method of investigation.
 - Console URLs, dashboard links, retention periods, region names when obvious.
 - Additional correct information beyond the reference.
 - Formatting details of identifiers when the resource is unambiguously identified.
 
-## Fail If
+### Fail If
 
 1. Wrong verdict (broken vs working).
 2. Wrong root cause that would not explain or fix the problem.
@@ -34,19 +36,27 @@ The answers are EQUIVALENT if a practitioner following the junior's answer would
 5. Missing a primary root cause the senior identified.
 6. Introduces false claims about the infrastructure that would mislead a practitioner. Minor imprecisions in non-actionable details do not count.
 
-## Clarifications
+### Clarifications
 
 - Omitting a detail is acceptable UNLESS it changes what action a practitioner would take.
 - Merely mentioning an approach is not the same as providing it as the solution.
 - Listing more resources than the reference says exist is NOT equivalent.
 - If the junior answers with a question and the senior gives an explicit answer, NOT equivalent.
 
-## Steps
+### Steps
 
 1. Read the instruction to understand what was asked.
 2. Identify what action a practitioner would take from the senior's answer.
 3. Check if the junior's answer leads to the same effective action.
 4. Check if any Fail condition applies.
 5. If same effective action and no fail condition: EQUIVALENT.
+
+## Per-Claim Grading
+
+This task's reference answer has been decomposed into the individual claims listed below. Score each claim independently, on its own merits -- whether the junior's answer covers other listed claims should not affect this one.
+
+- For each claim, judge whether the junior's answer in agent-output.txt supports it, allowing for differences in wording, formatting, or level of detail per the Must Match / May Differ / Fail If rules above.
+- A claim about a fix or remediation step is satisfied when the junior proposes an equivalent fix; a claim about a root cause is satisfied when the junior identifies an equivalent cause.
+- EXCEPTION: the claim named `no_extraneous_or_contradicting_facts` (if listed below) is judged differently from every other claim here -- follow its own description, which judges the answer as a WHOLE against the ENTIRE reference answer, not one isolated fact.
 
 {criteria}

--- a/tasks/databases-and-storage/report-unencrypted-s-buckets/tests/judge.toml
+++ b/tasks/databases-and-storage/report-unencrypted-s-buckets/tests/judge.toml
@@ -5,9 +5,24 @@ files = [
     "/tests/ground_truth.json",
 ]
 prompt_template = "judge_prompt.md"
-mode = "individual"
+mode = "batched"
 
 [[criterion]]
-name = "answers_equivalent"
-description = "Are the junior engineer's findings equivalent to the senior engineer's reference answer per the rubric?"
+name = "the_bucket_prod_bucket_jdn294ng4_uses_aws_kms_en"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The bucket prod-bucket-jdn294ng4 uses AWS KMS encryption (SSE-KMS with the AWS-managed key)"
+type = "binary"
+
+[[criterion]]
+name = "the_cdk_infrastructure_staging_buckets_use_kms_e"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The CDK infrastructure staging buckets use KMS encryption"
+type = "binary"
+
+[[criterion]]
+name = "all_other_buckets_use_the_default_s3_managed_enc"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): All other buckets use the default S3-managed encryption (SSE-S3/AES256). If the junior exhaustively and correctly lists which buckets use KMS encryption (matching the other claims above) without claiming that any additional bucket uses a non-default encryption scheme, that satisfies this claim by implication -- the junior does not need to explicitly restate that the remaining buckets use default encryption."
+type = "binary"
+
+[[criterion]]
+name = "no_extraneous_or_contradicting_facts"
+description = "Per the rubric's Fail-If and Clarifications rules, does the junior engineer's answer AVOID both of the following: (1) stating any fact that contradicts the reference answer's stated infrastructure state (e.g. a different count, the wrong resource, an opposite status), and (2) claiming the existence of additional resources, findings, or facts beyond what the reference answer states, in a way that would mislead a practitioner into a different conclusion or action. Judge the junior's answer as a whole against the entire reference answer for this, not any single claim. Answer 'yes' if the junior's answer contains no such contradiction or unsupported extra claim; answer 'no' if it does."
 type = "binary"

--- a/tasks/databases-and-storage/report-unencrypted-s-buckets/tests/judge_prompt.md
+++ b/tasks/databases-and-storage/report-unencrypted-s-buckets/tests/judge_prompt.md
@@ -7,25 +7,27 @@ You will be shown two files in the user message:
    - `instruction`: the task itself (what the user asked).
    - `expected_answer`: the senior engineer's reference answer.
 
-## Evaluation Standard
+## General Guidance
+
+### Evaluation Standard
 
 The answers are EQUIVALENT if a practitioner following the junior's answer would reach the same conclusion and take the same effective action as someone following the senior's answer.
 
-## Must Match
+### Must Match
 
 - The primary root cause or diagnosis.
 - The overall verdict (broken/working, how many, which resource).
 - All distinct root causes if the senior identifies multiple.
 - If a fix is proposed: it must actually work. A command missing required parameters or targeting the wrong resource is NOT equivalent, even if the diagnosis is correct.
 
-## May Differ
+### May Differ
 
 - Wording, formatting, level of detail, or method of investigation.
 - Console URLs, dashboard links, retention periods, region names when obvious.
 - Additional correct information beyond the reference.
 - Formatting details of identifiers when the resource is unambiguously identified.
 
-## Fail If
+### Fail If
 
 1. Wrong verdict (broken vs working).
 2. Wrong root cause that would not explain or fix the problem.
@@ -34,19 +36,27 @@ The answers are EQUIVALENT if a practitioner following the junior's answer would
 5. Missing a primary root cause the senior identified.
 6. Introduces false claims about the infrastructure that would mislead a practitioner. Minor imprecisions in non-actionable details do not count.
 
-## Clarifications
+### Clarifications
 
 - Omitting a detail is acceptable UNLESS it changes what action a practitioner would take.
 - Merely mentioning an approach is not the same as providing it as the solution.
 - Listing more resources than the reference says exist is NOT equivalent.
 - If the junior answers with a question and the senior gives an explicit answer, NOT equivalent.
 
-## Steps
+### Steps
 
 1. Read the instruction to understand what was asked.
 2. Identify what action a practitioner would take from the senior's answer.
 3. Check if the junior's answer leads to the same effective action.
 4. Check if any Fail condition applies.
 5. If same effective action and no fail condition: EQUIVALENT.
+
+## Per-Claim Grading
+
+This task's reference answer has been decomposed into the individual claims listed below. Score each claim independently, on its own merits -- whether the junior's answer covers other listed claims should not affect this one.
+
+- For each claim, judge whether the junior's answer in agent-output.txt supports it, allowing for differences in wording, formatting, or level of detail per the Must Match / May Differ / Fail If rules above.
+- A claim about a fix or remediation step is satisfied when the junior proposes an equivalent fix; a claim about a root cause is satisfied when the junior identifies an equivalent cause.
+- EXCEPTION: the claim named `no_extraneous_or_contradicting_facts` (if listed below) is judged differently from every other claim here -- follow its own description, which judges the answer as a WHOLE against the ENTIRE reference answer, not one isolated fact.
 
 {criteria}

--- a/tasks/databases-and-storage/retrieve-s-csv-object-contents/tests/judge.toml
+++ b/tasks/databases-and-storage/retrieve-s-csv-object-contents/tests/judge.toml
@@ -5,9 +5,19 @@ files = [
     "/tests/ground_truth.json",
 ]
 prompt_template = "judge_prompt.md"
-mode = "individual"
+mode = "batched"
 
 [[criterion]]
-name = "answers_equivalent"
-description = "Are the junior engineer's findings equivalent to the senior engineer's reference answer per the rubric?"
+name = "the_csv_object_file_databases_and_storage_s3_jkd"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The CSV object file {{databases-and-storage-s3-jkdf342er-us-east-1-ObjectName}} exists in S3 bucket {{databases-and-storage-s3-jkdf342er-us-east-1-BucketName}}"
+type = "binary"
+
+[[criterion]]
+name = "the_contents_of_databases_and_storage_s3_jkdf342"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The contents of {{databases-and-storage-s3-jkdf342er-us-east-1-ObjectName}} are: Name,Age,City\\nJohn,25,New York\\nJane,30,London\\nBob,35,Paris"
+type = "binary"
+
+[[criterion]]
+name = "no_extraneous_or_contradicting_facts"
+description = "Per the rubric's Fail-If and Clarifications rules, does the junior engineer's answer AVOID both of the following: (1) stating any fact that contradicts the reference answer's stated infrastructure state (e.g. a different count, the wrong resource, an opposite status), and (2) claiming the existence of additional resources, findings, or facts beyond what the reference answer states, in a way that would mislead a practitioner into a different conclusion or action. Judge the junior's answer as a whole against the entire reference answer for this, not any single claim. Answer 'yes' if the junior's answer contains no such contradiction or unsupported extra claim; answer 'no' if it does."
 type = "binary"

--- a/tasks/databases-and-storage/retrieve-s-csv-object-contents/tests/judge_prompt.md
+++ b/tasks/databases-and-storage/retrieve-s-csv-object-contents/tests/judge_prompt.md
@@ -7,25 +7,27 @@ You will be shown two files in the user message:
    - `instruction`: the task itself (what the user asked).
    - `expected_answer`: the senior engineer's reference answer.
 
-## Evaluation Standard
+## General Guidance
+
+### Evaluation Standard
 
 The answers are EQUIVALENT if a practitioner following the junior's answer would reach the same conclusion and take the same effective action as someone following the senior's answer.
 
-## Must Match
+### Must Match
 
 - The primary root cause or diagnosis.
 - The overall verdict (broken/working, how many, which resource).
 - All distinct root causes if the senior identifies multiple.
 - If a fix is proposed: it must actually work. A command missing required parameters or targeting the wrong resource is NOT equivalent, even if the diagnosis is correct.
 
-## May Differ
+### May Differ
 
 - Wording, formatting, level of detail, or method of investigation.
 - Console URLs, dashboard links, retention periods, region names when obvious.
 - Additional correct information beyond the reference.
 - Formatting details of identifiers when the resource is unambiguously identified.
 
-## Fail If
+### Fail If
 
 1. Wrong verdict (broken vs working).
 2. Wrong root cause that would not explain or fix the problem.
@@ -34,19 +36,27 @@ The answers are EQUIVALENT if a practitioner following the junior's answer would
 5. Missing a primary root cause the senior identified.
 6. Introduces false claims about the infrastructure that would mislead a practitioner. Minor imprecisions in non-actionable details do not count.
 
-## Clarifications
+### Clarifications
 
 - Omitting a detail is acceptable UNLESS it changes what action a practitioner would take.
 - Merely mentioning an approach is not the same as providing it as the solution.
 - Listing more resources than the reference says exist is NOT equivalent.
 - If the junior answers with a question and the senior gives an explicit answer, NOT equivalent.
 
-## Steps
+### Steps
 
 1. Read the instruction to understand what was asked.
 2. Identify what action a practitioner would take from the senior's answer.
 3. Check if the junior's answer leads to the same effective action.
 4. Check if any Fail condition applies.
 5. If same effective action and no fail condition: EQUIVALENT.
+
+## Per-Claim Grading
+
+This task's reference answer has been decomposed into the individual claims listed below. Score each claim independently, on its own merits -- whether the junior's answer covers other listed claims should not affect this one.
+
+- For each claim, judge whether the junior's answer in agent-output.txt supports it, allowing for differences in wording, formatting, or level of detail per the Must Match / May Differ / Fail If rules above.
+- A claim about a fix or remediation step is satisfied when the junior proposes an equivalent fix; a claim about a root cause is satisfied when the junior identifies an equivalent cause.
+- EXCEPTION: the claim named `no_extraneous_or_contradicting_facts` (if listed below) is judged differently from every other claim here -- follow its own description, which judges the answer as a WHOLE against the ENTIRE reference answer, not one isolated fact.
 
 {criteria}

--- a/tasks/databases-and-storage/retrieve-s-text-file-contents/tests/judge.toml
+++ b/tasks/databases-and-storage/retrieve-s-text-file-contents/tests/judge.toml
@@ -5,9 +5,19 @@ files = [
     "/tests/ground_truth.json",
 ]
 prompt_template = "judge_prompt.md"
-mode = "individual"
+mode = "batched"
 
 [[criterion]]
-name = "answers_equivalent"
-description = "Are the junior engineer's findings equivalent to the senior engineer's reference answer per the rubric?"
+name = "the_most_similar_file_among_all_s3_buckets_is_sa"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The most similar file among all S3 buckets is 'samplefile.txt'"
+type = "binary"
+
+[[criterion]]
+name = "the_content_of_samplefile_txt_is_hello_this_is_a"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The content of 'samplefile.txt' is 'Hello, this is a sample text file!'"
+type = "binary"
+
+[[criterion]]
+name = "no_extraneous_or_contradicting_facts"
+description = "Per the rubric's Fail-If and Clarifications rules, does the junior engineer's answer AVOID both of the following: (1) stating any fact that contradicts the reference answer's stated infrastructure state (e.g. a different count, the wrong resource, an opposite status), and (2) claiming the existence of additional resources, findings, or facts beyond what the reference answer states, in a way that would mislead a practitioner into a different conclusion or action. Judge the junior's answer as a whole against the entire reference answer for this, not any single claim. Answer 'yes' if the junior's answer contains no such contradiction or unsupported extra claim; answer 'no' if it does."
 type = "binary"

--- a/tasks/databases-and-storage/retrieve-s-text-file-contents/tests/judge_prompt.md
+++ b/tasks/databases-and-storage/retrieve-s-text-file-contents/tests/judge_prompt.md
@@ -7,25 +7,27 @@ You will be shown two files in the user message:
    - `instruction`: the task itself (what the user asked).
    - `expected_answer`: the senior engineer's reference answer.
 
-## Evaluation Standard
+## General Guidance
+
+### Evaluation Standard
 
 The answers are EQUIVALENT if a practitioner following the junior's answer would reach the same conclusion and take the same effective action as someone following the senior's answer.
 
-## Must Match
+### Must Match
 
 - The primary root cause or diagnosis.
 - The overall verdict (broken/working, how many, which resource).
 - All distinct root causes if the senior identifies multiple.
 - If a fix is proposed: it must actually work. A command missing required parameters or targeting the wrong resource is NOT equivalent, even if the diagnosis is correct.
 
-## May Differ
+### May Differ
 
 - Wording, formatting, level of detail, or method of investigation.
 - Console URLs, dashboard links, retention periods, region names when obvious.
 - Additional correct information beyond the reference.
 - Formatting details of identifiers when the resource is unambiguously identified.
 
-## Fail If
+### Fail If
 
 1. Wrong verdict (broken vs working).
 2. Wrong root cause that would not explain or fix the problem.
@@ -34,19 +36,27 @@ The answers are EQUIVALENT if a practitioner following the junior's answer would
 5. Missing a primary root cause the senior identified.
 6. Introduces false claims about the infrastructure that would mislead a practitioner. Minor imprecisions in non-actionable details do not count.
 
-## Clarifications
+### Clarifications
 
 - Omitting a detail is acceptable UNLESS it changes what action a practitioner would take.
 - Merely mentioning an approach is not the same as providing it as the solution.
 - Listing more resources than the reference says exist is NOT equivalent.
 - If the junior answers with a question and the senior gives an explicit answer, NOT equivalent.
 
-## Steps
+### Steps
 
 1. Read the instruction to understand what was asked.
 2. Identify what action a practitioner would take from the senior's answer.
 3. Check if the junior's answer leads to the same effective action.
 4. Check if any Fail condition applies.
 5. If same effective action and no fail condition: EQUIVALENT.
+
+## Per-Claim Grading
+
+This task's reference answer has been decomposed into the individual claims listed below. Score each claim independently, on its own merits -- whether the junior's answer covers other listed claims should not affect this one.
+
+- For each claim, judge whether the junior's answer in agent-output.txt supports it, allowing for differences in wording, formatting, or level of detail per the Must Match / May Differ / Fail If rules above.
+- A claim about a fix or remediation step is satisfied when the junior proposes an equivalent fix; a claim about a root cause is satisfied when the junior identifies an equivalent cause.
+- EXCEPTION: the claim named `no_extraneous_or_contradicting_facts` (if listed below) is judged differently from every other claim here -- follow its own description, which judges the answer as a WHOLE against the ENTIRE reference answer, not one isolated fact.
 
 {criteria}

--- a/tasks/databases-and-storage/s-download-csv-identify-columns/tests/judge.toml
+++ b/tasks/databases-and-storage/s-download-csv-identify-columns/tests/judge.toml
@@ -5,9 +5,24 @@ files = [
     "/tests/ground_truth.json",
 ]
 prompt_template = "judge_prompt.md"
-mode = "individual"
+mode = "batched"
 
 [[criterion]]
-name = "answers_equivalent"
-description = "Are the junior engineer's findings equivalent to the senior engineer's reference answer per the rubric?"
+name = "the_csv_file_has_6_columns_product_id_name_categ"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The CSV file has 6 columns: product_id, name, category, price, stock, and description."
+type = "binary"
+
+[[criterion]]
+name = "columns_with_all_unique_values_product_id_name_p"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): Columns with all unique values: product_id, name, price, stock, and description."
+type = "binary"
+
+[[criterion]]
+name = "column_with_duplicate_values_category_e_g_electr"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): Column with duplicate values: category (e.g., 'Electronics' appears more than once)."
+type = "binary"
+
+[[criterion]]
+name = "no_extraneous_or_contradicting_facts"
+description = "Per the rubric's Fail-If and Clarifications rules, does the junior engineer's answer AVOID both of the following: (1) stating any fact that contradicts the reference answer's stated infrastructure state (e.g. a different count, the wrong resource, an opposite status), and (2) claiming the existence of additional resources, findings, or facts beyond what the reference answer states, in a way that would mislead a practitioner into a different conclusion or action. Judge the junior's answer as a whole against the entire reference answer for this, not any single claim. Answer 'yes' if the junior's answer contains no such contradiction or unsupported extra claim; answer 'no' if it does."
 type = "binary"

--- a/tasks/databases-and-storage/s-download-csv-identify-columns/tests/judge_prompt.md
+++ b/tasks/databases-and-storage/s-download-csv-identify-columns/tests/judge_prompt.md
@@ -7,25 +7,27 @@ You will be shown two files in the user message:
    - `instruction`: the task itself (what the user asked).
    - `expected_answer`: the senior engineer's reference answer.
 
-## Evaluation Standard
+## General Guidance
+
+### Evaluation Standard
 
 The answers are EQUIVALENT if a practitioner following the junior's answer would reach the same conclusion and take the same effective action as someone following the senior's answer.
 
-## Must Match
+### Must Match
 
 - The primary root cause or diagnosis.
 - The overall verdict (broken/working, how many, which resource).
 - All distinct root causes if the senior identifies multiple.
 - If a fix is proposed: it must actually work. A command missing required parameters or targeting the wrong resource is NOT equivalent, even if the diagnosis is correct.
 
-## May Differ
+### May Differ
 
 - Wording, formatting, level of detail, or method of investigation.
 - Console URLs, dashboard links, retention periods, region names when obvious.
 - Additional correct information beyond the reference.
 - Formatting details of identifiers when the resource is unambiguously identified.
 
-## Fail If
+### Fail If
 
 1. Wrong verdict (broken vs working).
 2. Wrong root cause that would not explain or fix the problem.
@@ -34,19 +36,27 @@ The answers are EQUIVALENT if a practitioner following the junior's answer would
 5. Missing a primary root cause the senior identified.
 6. Introduces false claims about the infrastructure that would mislead a practitioner. Minor imprecisions in non-actionable details do not count.
 
-## Clarifications
+### Clarifications
 
 - Omitting a detail is acceptable UNLESS it changes what action a practitioner would take.
 - Merely mentioning an approach is not the same as providing it as the solution.
 - Listing more resources than the reference says exist is NOT equivalent.
 - If the junior answers with a question and the senior gives an explicit answer, NOT equivalent.
 
-## Steps
+### Steps
 
 1. Read the instruction to understand what was asked.
 2. Identify what action a practitioner would take from the senior's answer.
 3. Check if the junior's answer leads to the same effective action.
 4. Check if any Fail condition applies.
 5. If same effective action and no fail condition: EQUIVALENT.
+
+## Per-Claim Grading
+
+This task's reference answer has been decomposed into the individual claims listed below. Score each claim independently, on its own merits -- whether the junior's answer covers other listed claims should not affect this one.
+
+- For each claim, judge whether the junior's answer in agent-output.txt supports it, allowing for differences in wording, formatting, or level of detail per the Must Match / May Differ / Fail If rules above.
+- A claim about a fix or remediation step is satisfied when the junior proposes an equivalent fix; a claim about a root cause is satisfied when the junior identifies an equivalent cause.
+- EXCEPTION: the claim named `no_extraneous_or_contradicting_facts` (if listed below) is judged differently from every other claim here -- follow its own description, which judges the answer as a WHOLE against the ENTIRE reference answer, not one isolated fact.
 
 {criteria}

--- a/tasks/databases-and-storage/s-object-versions-and-metadata/tests/judge.toml
+++ b/tasks/databases-and-storage/s-object-versions-and-metadata/tests/judge.toml
@@ -5,9 +5,29 @@ files = [
     "/tests/ground_truth.json",
 ]
 prompt_template = "judge_prompt.md"
-mode = "individual"
+mode = "batched"
 
 [[criterion]]
-name = "answers_equivalent"
-description = "Are the junior engineer's findings equivalent to the senior engineer's reference answer per the rubric?"
+name = "the_most_recently_modified_object_is_898c7f19_mo"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The most recently modified object is `{{898c7f19-MostRecentKey}}`"
+type = "binary"
+
+[[criterion]]
+name = "the_most_recently_modified_object_has_version_id"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The most recently modified object has version ID `{{898c7f19-MostRecentVersionId}}`"
+type = "binary"
+
+[[criterion]]
+name = "the_object_prod_data_txt_has_version_id_898c7f19"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The object `prod_data.txt` has version ID `{{898c7f19-ProdDataVersionId}}`"
+type = "binary"
+
+[[criterion]]
+name = "the_object_prod_data_txt_is_898c7f19_proddatasiz"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The object `prod_data.txt` is {{898c7f19-ProdDataSizeBytes}} bytes"
+type = "binary"
+
+[[criterion]]
+name = "no_extraneous_or_contradicting_facts"
+description = "Per the rubric's Fail-If and Clarifications rules, does the junior engineer's answer AVOID both of the following: (1) stating any fact that contradicts the reference answer's stated infrastructure state (e.g. a different count, the wrong resource, an opposite status), and (2) claiming the existence of additional resources, findings, or facts beyond what the reference answer states, in a way that would mislead a practitioner into a different conclusion or action. Judge the junior's answer as a whole against the entire reference answer for this, not any single claim. Answer 'yes' if the junior's answer contains no such contradiction or unsupported extra claim; answer 'no' if it does."
 type = "binary"

--- a/tasks/databases-and-storage/s-object-versions-and-metadata/tests/judge_prompt.md
+++ b/tasks/databases-and-storage/s-object-versions-and-metadata/tests/judge_prompt.md
@@ -7,25 +7,27 @@ You will be shown two files in the user message:
    - `instruction`: the task itself (what the user asked).
    - `expected_answer`: the senior engineer's reference answer.
 
-## Evaluation Standard
+## General Guidance
+
+### Evaluation Standard
 
 The answers are EQUIVALENT if a practitioner following the junior's answer would reach the same conclusion and take the same effective action as someone following the senior's answer.
 
-## Must Match
+### Must Match
 
 - The primary root cause or diagnosis.
 - The overall verdict (broken/working, how many, which resource).
 - All distinct root causes if the senior identifies multiple.
 - If a fix is proposed: it must actually work. A command missing required parameters or targeting the wrong resource is NOT equivalent, even if the diagnosis is correct.
 
-## May Differ
+### May Differ
 
 - Wording, formatting, level of detail, or method of investigation.
 - Console URLs, dashboard links, retention periods, region names when obvious.
 - Additional correct information beyond the reference.
 - Formatting details of identifiers when the resource is unambiguously identified.
 
-## Fail If
+### Fail If
 
 1. Wrong verdict (broken vs working).
 2. Wrong root cause that would not explain or fix the problem.
@@ -34,19 +36,27 @@ The answers are EQUIVALENT if a practitioner following the junior's answer would
 5. Missing a primary root cause the senior identified.
 6. Introduces false claims about the infrastructure that would mislead a practitioner. Minor imprecisions in non-actionable details do not count.
 
-## Clarifications
+### Clarifications
 
 - Omitting a detail is acceptable UNLESS it changes what action a practitioner would take.
 - Merely mentioning an approach is not the same as providing it as the solution.
 - Listing more resources than the reference says exist is NOT equivalent.
 - If the junior answers with a question and the senior gives an explicit answer, NOT equivalent.
 
-## Steps
+### Steps
 
 1. Read the instruction to understand what was asked.
 2. Identify what action a practitioner would take from the senior's answer.
 3. Check if the junior's answer leads to the same effective action.
 4. Check if any Fail condition applies.
 5. If same effective action and no fail condition: EQUIVALENT.
+
+## Per-Claim Grading
+
+This task's reference answer has been decomposed into the individual claims listed below. Score each claim independently, on its own merits -- whether the junior's answer covers other listed claims should not affect this one.
+
+- For each claim, judge whether the junior's answer in agent-output.txt supports it, allowing for differences in wording, formatting, or level of detail per the Must Match / May Differ / Fail If rules above.
+- A claim about a fix or remediation step is satisfied when the junior proposes an equivalent fix; a claim about a root cause is satisfied when the junior identifies an equivalent cause.
+- EXCEPTION: the claim named `no_extraneous_or_contradicting_facts` (if listed below) is judged differently from every other claim here -- follow its own description, which judges the answer as a WHOLE against the ENTIRE reference answer, not one isolated fact.
 
 {criteria}

--- a/tasks/databases-and-storage/scan-dynamodb-table-by-status/tests/judge.toml
+++ b/tasks/databases-and-storage/scan-dynamodb-table-by-status/tests/judge.toml
@@ -5,9 +5,19 @@ files = [
     "/tests/ground_truth.json",
 ]
 prompt_template = "judge_prompt.md"
-mode = "individual"
+mode = "batched"
 
 [[criterion]]
-name = "answers_equivalent"
-description = "Are the junior engineer's findings equivalent to the senior engineer's reference answer per the rubric?"
+name = "the_dynamodb_table_databases_and_storage_dynamod"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The DynamoDB table {{databases-and-storage-dynamodb-kdf231sdf-us-east-1-TableName}} retrieved 5 records"
+type = "binary"
+
+[[criterion]]
+name = "the_retrieved_records_have_statuses_including_ac"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The retrieved records have statuses including active, inactive, pending, and suspended users"
+type = "binary"
+
+[[criterion]]
+name = "no_extraneous_or_contradicting_facts"
+description = "Per the rubric's Fail-If and Clarifications rules, does the junior engineer's answer AVOID both of the following: (1) stating any fact that contradicts the reference answer's stated infrastructure state (e.g. a different count, the wrong resource, an opposite status), and (2) claiming the existence of additional resources, findings, or facts beyond what the reference answer states, in a way that would mislead a practitioner into a different conclusion or action. Judge the junior's answer as a whole against the entire reference answer for this, not any single claim. Answer 'yes' if the junior's answer contains no such contradiction or unsupported extra claim; answer 'no' if it does."
 type = "binary"

--- a/tasks/databases-and-storage/scan-dynamodb-table-by-status/tests/judge_prompt.md
+++ b/tasks/databases-and-storage/scan-dynamodb-table-by-status/tests/judge_prompt.md
@@ -7,25 +7,27 @@ You will be shown two files in the user message:
    - `instruction`: the task itself (what the user asked).
    - `expected_answer`: the senior engineer's reference answer.
 
-## Evaluation Standard
+## General Guidance
+
+### Evaluation Standard
 
 The answers are EQUIVALENT if a practitioner following the junior's answer would reach the same conclusion and take the same effective action as someone following the senior's answer.
 
-## Must Match
+### Must Match
 
 - The primary root cause or diagnosis.
 - The overall verdict (broken/working, how many, which resource).
 - All distinct root causes if the senior identifies multiple.
 - If a fix is proposed: it must actually work. A command missing required parameters or targeting the wrong resource is NOT equivalent, even if the diagnosis is correct.
 
-## May Differ
+### May Differ
 
 - Wording, formatting, level of detail, or method of investigation.
 - Console URLs, dashboard links, retention periods, region names when obvious.
 - Additional correct information beyond the reference.
 - Formatting details of identifiers when the resource is unambiguously identified.
 
-## Fail If
+### Fail If
 
 1. Wrong verdict (broken vs working).
 2. Wrong root cause that would not explain or fix the problem.
@@ -34,19 +36,27 @@ The answers are EQUIVALENT if a practitioner following the junior's answer would
 5. Missing a primary root cause the senior identified.
 6. Introduces false claims about the infrastructure that would mislead a practitioner. Minor imprecisions in non-actionable details do not count.
 
-## Clarifications
+### Clarifications
 
 - Omitting a detail is acceptable UNLESS it changes what action a practitioner would take.
 - Merely mentioning an approach is not the same as providing it as the solution.
 - Listing more resources than the reference says exist is NOT equivalent.
 - If the junior answers with a question and the senior gives an explicit answer, NOT equivalent.
 
-## Steps
+### Steps
 
 1. Read the instruction to understand what was asked.
 2. Identify what action a practitioner would take from the senior's answer.
 3. Check if the junior's answer leads to the same effective action.
 4. Check if any Fail condition applies.
 5. If same effective action and no fail condition: EQUIVALENT.
+
+## Per-Claim Grading
+
+This task's reference answer has been decomposed into the individual claims listed below. Score each claim independently, on its own merits -- whether the junior's answer covers other listed claims should not affect this one.
+
+- For each claim, judge whether the junior's answer in agent-output.txt supports it, allowing for differences in wording, formatting, or level of detail per the Must Match / May Differ / Fail If rules above.
+- A claim about a fix or remediation step is satisfied when the junior proposes an equivalent fix; a claim about a root cause is satisfied when the junior identifies an equivalent cause.
+- EXCEPTION: the claim named `no_extraneous_or_contradicting_facts` (if listed below) is judged differently from every other claim here -- follow its own description, which judges the answer as a WHOLE against the ENTIRE reference answer, not one isolated fact.
 
 {criteria}

--- a/tasks/serverless-apps/check-lambda-layers-s-code/tests/judge.toml
+++ b/tasks/serverless-apps/check-lambda-layers-s-code/tests/judge.toml
@@ -5,9 +5,14 @@ files = [
     "/tests/ground_truth.json",
 ]
 prompt_template = "judge_prompt.md"
-mode = "individual"
+mode = "batched"
 
 [[criterion]]
-name = "answers_equivalent"
-description = "Are the junior engineer's findings equivalent to the senior engineer's reference answer per the rubric?"
+name = "serverless_apps_lambdamisc_us_east_1_s3layerarne"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): {{serverless-apps-LambdaMisc-us-east-1-S3LayerArnExport}} is using code hosted on S3"
+type = "binary"
+
+[[criterion]]
+name = "no_extraneous_or_contradicting_facts"
+description = "Per the rubric's Fail-If and Clarifications rules, does the junior engineer's answer AVOID both of the following: (1) stating any fact that contradicts the reference answer's stated infrastructure state (e.g. a different count, the wrong resource, an opposite status), and (2) claiming the existence of additional resources, findings, or facts beyond what the reference answer states, in a way that would mislead a practitioner into a different conclusion or action. Judge the junior's answer as a whole against the entire reference answer for this, not any single claim. Answer 'yes' if the junior's answer contains no such contradiction or unsupported extra claim; answer 'no' if it does."
 type = "binary"

--- a/tasks/serverless-apps/check-lambda-layers-s-code/tests/judge_prompt.md
+++ b/tasks/serverless-apps/check-lambda-layers-s-code/tests/judge_prompt.md
@@ -7,25 +7,27 @@ You will be shown two files in the user message:
    - `instruction`: the task itself (what the user asked).
    - `expected_answer`: the senior engineer's reference answer.
 
-## Evaluation Standard
+## General Guidance
+
+### Evaluation Standard
 
 The answers are EQUIVALENT if a practitioner following the junior's answer would reach the same conclusion and take the same effective action as someone following the senior's answer.
 
-## Must Match
+### Must Match
 
 - The primary root cause or diagnosis.
 - The overall verdict (broken/working, how many, which resource).
 - All distinct root causes if the senior identifies multiple.
 - If a fix is proposed: it must actually work. A command missing required parameters or targeting the wrong resource is NOT equivalent, even if the diagnosis is correct.
 
-## May Differ
+### May Differ
 
 - Wording, formatting, level of detail, or method of investigation.
 - Console URLs, dashboard links, retention periods, region names when obvious.
 - Additional correct information beyond the reference.
 - Formatting details of identifiers when the resource is unambiguously identified.
 
-## Fail If
+### Fail If
 
 1. Wrong verdict (broken vs working).
 2. Wrong root cause that would not explain or fix the problem.
@@ -34,19 +36,27 @@ The answers are EQUIVALENT if a practitioner following the junior's answer would
 5. Missing a primary root cause the senior identified.
 6. Introduces false claims about the infrastructure that would mislead a practitioner. Minor imprecisions in non-actionable details do not count.
 
-## Clarifications
+### Clarifications
 
 - Omitting a detail is acceptable UNLESS it changes what action a practitioner would take.
 - Merely mentioning an approach is not the same as providing it as the solution.
 - Listing more resources than the reference says exist is NOT equivalent.
 - If the junior answers with a question and the senior gives an explicit answer, NOT equivalent.
 
-## Steps
+### Steps
 
 1. Read the instruction to understand what was asked.
 2. Identify what action a practitioner would take from the senior's answer.
 3. Check if the junior's answer leads to the same effective action.
 4. Check if any Fail condition applies.
 5. If same effective action and no fail condition: EQUIVALENT.
+
+## Per-Claim Grading
+
+This task's reference answer has been decomposed into the individual claims listed below. Score each claim independently, on its own merits -- whether the junior's answer covers other listed claims should not affect this one.
+
+- For each claim, judge whether the junior's answer in agent-output.txt supports it, allowing for differences in wording, formatting, or level of detail per the Must Match / May Differ / Fail If rules above.
+- A claim about a fix or remediation step is satisfied when the junior proposes an equivalent fix; a claim about a root cause is satisfied when the junior identifies an equivalent cause.
+- EXCEPTION: the claim named `no_extraneous_or_contradicting_facts` (if listed below) is judged differently from every other claim here -- follow its own description, which judges the answer as a WHOLE against the ENTIRE reference answer, not one isolated fact.
 
 {criteria}

--- a/tasks/serverless-apps/check-s-buckets-public-access/tests/judge.toml
+++ b/tasks/serverless-apps/check-s-buckets-public-access/tests/judge.toml
@@ -5,9 +5,54 @@ files = [
     "/tests/ground_truth.json",
 ]
 prompt_template = "judge_prompt.md"
-mode = "individual"
+mode = "batched"
 
 [[criterion]]
-name = "answers_equivalent"
-description = "Are the junior engineer's findings equivalent to the senior engineer's reference answer per the rubric?"
+name = "serverless_apps_s3storage_us_east_1_analyticsbuc"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): {{serverless-apps-S3Storage-us-east-1-AnalyticsBucketName}} has BlockPublicAcls false"
+type = "binary"
+
+[[criterion]]
+name = "serverless_apps_s3storage_us_east_1_analyticsbuc_2"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): {{serverless-apps-S3Storage-us-east-1-AnalyticsBucketName}} has IgnorePublicAcls true"
+type = "binary"
+
+[[criterion]]
+name = "serverless_apps_s3storage_us_east_1_analyticsbuc_3"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): {{serverless-apps-S3Storage-us-east-1-AnalyticsBucketName}} has BlockPublicPolicy true"
+type = "binary"
+
+[[criterion]]
+name = "serverless_apps_s3storage_us_east_1_analyticsbuc_4"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): {{serverless-apps-S3Storage-us-east-1-AnalyticsBucketName}} has RestrictPublicBuckets true"
+type = "binary"
+
+[[criterion]]
+name = "every_bucket_other_than_serverless_apps_s3storag"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): Every bucket other than {{serverless-apps-S3Storage-us-east-1-AnalyticsBucketName}} has all four public access block settings (BlockPublicAcls, IgnorePublicAcls, BlockPublicPolicy, RestrictPublicBuckets) set to true"
+type = "binary"
+
+[[criterion]]
+name = "the_gap_in_serverless_apps_s3storage_us_east_1_a"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The gap in {{serverless-apps-S3Storage-us-east-1-AnalyticsBucketName}} (BlockPublicAcls false while other settings are true) does not actually expose it to public access"
+type = "binary"
+
+[[criterion]]
+name = "ignorepublicacls_true_makes_s3_ignore_any_public"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): IgnorePublicAcls=true makes S3 ignore any public ACLs that BlockPublicAcls=false would otherwise allow. The instruction only asks whether the gap leaves the bucket exposed, not to enumerate every contributing setting -- credit this claim if the junior correctly concludes/explains the bucket is not exposed via any valid reasoning (e.g. citing Object Ownership settings, BlockPublicPolicy+RestrictPublicBuckets, or the settings as a whole), without requiring IgnorePublicAcls to be named specifically as the mechanism."
+type = "binary"
+
+[[criterion]]
+name = "blockpublicpolicy_true_plus_restrictpublicbucket"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): the bucket's overall public-access-block configuration (despite BlockPublicAcls being false) prevents public access via bucket policy or access points. The instruction only asks whether the gap leaves the bucket exposed, not to enumerate every contributing setting -- credit this claim if the junior correctly concludes/explains the bucket is not exposed via any valid reasoning (e.g. citing IgnorePublicAcls, the absence of a bucket policy, or the settings as a whole), without requiring BlockPublicPolicy and RestrictPublicBuckets to be named specifically."
+type = "binary"
+
+[[criterion]]
+name = "none_of_the_buckets_currently_allow_public_acces"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): None of the buckets currently allow public access"
+type = "binary"
+
+[[criterion]]
+name = "no_extraneous_or_contradicting_facts"
+description = "Per the rubric's Fail-If and Clarifications rules, does the junior engineer's answer AVOID both of the following: (1) stating any fact that contradicts the reference answer's stated infrastructure state (e.g. a different count, the wrong resource, an opposite status), and (2) claiming the existence of additional resources, findings, or facts beyond what the reference answer states, in a way that would mislead a practitioner into a different conclusion or action. Judge the junior's answer as a whole against the entire reference answer for this, not any single claim. Answer 'yes' if the junior's answer contains no such contradiction or unsupported extra claim; answer 'no' if it does."
 type = "binary"

--- a/tasks/serverless-apps/check-s-buckets-public-access/tests/judge_prompt.md
+++ b/tasks/serverless-apps/check-s-buckets-public-access/tests/judge_prompt.md
@@ -7,25 +7,27 @@ You will be shown two files in the user message:
    - `instruction`: the task itself (what the user asked).
    - `expected_answer`: the senior engineer's reference answer.
 
-## Evaluation Standard
+## General Guidance
+
+### Evaluation Standard
 
 The answers are EQUIVALENT if a practitioner following the junior's answer would reach the same conclusion and take the same effective action as someone following the senior's answer.
 
-## Must Match
+### Must Match
 
 - The primary root cause or diagnosis.
 - The overall verdict (broken/working, how many, which resource).
 - All distinct root causes if the senior identifies multiple.
 - If a fix is proposed: it must actually work. A command missing required parameters or targeting the wrong resource is NOT equivalent, even if the diagnosis is correct.
 
-## May Differ
+### May Differ
 
 - Wording, formatting, level of detail, or method of investigation.
 - Console URLs, dashboard links, retention periods, region names when obvious.
 - Additional correct information beyond the reference.
 - Formatting details of identifiers when the resource is unambiguously identified.
 
-## Fail If
+### Fail If
 
 1. Wrong verdict (broken vs working).
 2. Wrong root cause that would not explain or fix the problem.
@@ -34,19 +36,27 @@ The answers are EQUIVALENT if a practitioner following the junior's answer would
 5. Missing a primary root cause the senior identified.
 6. Introduces false claims about the infrastructure that would mislead a practitioner. Minor imprecisions in non-actionable details do not count.
 
-## Clarifications
+### Clarifications
 
 - Omitting a detail is acceptable UNLESS it changes what action a practitioner would take.
 - Merely mentioning an approach is not the same as providing it as the solution.
 - Listing more resources than the reference says exist is NOT equivalent.
 - If the junior answers with a question and the senior gives an explicit answer, NOT equivalent.
 
-## Steps
+### Steps
 
 1. Read the instruction to understand what was asked.
 2. Identify what action a practitioner would take from the senior's answer.
 3. Check if the junior's answer leads to the same effective action.
 4. Check if any Fail condition applies.
 5. If same effective action and no fail condition: EQUIVALENT.
+
+## Per-Claim Grading
+
+This task's reference answer has been decomposed into the individual claims listed below. Score each claim independently, on its own merits -- whether the junior's answer covers other listed claims should not affect this one.
+
+- For each claim, judge whether the junior's answer in agent-output.txt supports it, allowing for differences in wording, formatting, or level of detail per the Must Match / May Differ / Fail If rules above.
+- A claim about a fix or remediation step is satisfied when the junior proposes an equivalent fix; a claim about a root cause is satisfied when the junior identifies an equivalent cause.
+- EXCEPTION: the claim named `no_extraneous_or_contradicting_facts` (if listed below) is judged differently from every other claim here -- follow its own description, which judges the answer as a WHOLE against the ENTIRE reference answer, not one isolated fact.
 
 {criteria}

--- a/tasks/serverless-apps/check-s-lifecycle-tag-filter-rules/tests/judge.toml
+++ b/tasks/serverless-apps/check-s-lifecycle-tag-filter-rules/tests/judge.toml
@@ -5,9 +5,14 @@ files = [
     "/tests/ground_truth.json",
 ]
 prompt_template = "judge_prompt.md"
-mode = "individual"
+mode = "batched"
 
 [[criterion]]
-name = "answers_equivalent"
-description = "Are the junior engineer's findings equivalent to the senior engineer's reference answer per the rubric?"
+name = "the_bucket_serverless_apps_s3storage_us_east_1_l"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The bucket {{serverless-apps-S3Storage-us-east-1-LifeCycleBucket}} has a lifecycle expiration rule that deletes objects after 1 day when tagged with shouldDelete: true."
+type = "binary"
+
+[[criterion]]
+name = "no_extraneous_or_contradicting_facts"
+description = "Per the rubric's Fail-If and Clarifications rules, does the junior engineer's answer AVOID both of the following: (1) stating any fact that contradicts the reference answer's stated infrastructure state (e.g. a different count, the wrong resource, an opposite status), and (2) claiming the existence of additional resources, findings, or facts beyond what the reference answer states, in a way that would mislead a practitioner into a different conclusion or action. Judge the junior's answer as a whole against the entire reference answer for this, not any single claim. Answer 'yes' if the junior's answer contains no such contradiction or unsupported extra claim; answer 'no' if it does."
 type = "binary"

--- a/tasks/serverless-apps/check-s-lifecycle-tag-filter-rules/tests/judge_prompt.md
+++ b/tasks/serverless-apps/check-s-lifecycle-tag-filter-rules/tests/judge_prompt.md
@@ -7,25 +7,27 @@ You will be shown two files in the user message:
    - `instruction`: the task itself (what the user asked).
    - `expected_answer`: the senior engineer's reference answer.
 
-## Evaluation Standard
+## General Guidance
+
+### Evaluation Standard
 
 The answers are EQUIVALENT if a practitioner following the junior's answer would reach the same conclusion and take the same effective action as someone following the senior's answer.
 
-## Must Match
+### Must Match
 
 - The primary root cause or diagnosis.
 - The overall verdict (broken/working, how many, which resource).
 - All distinct root causes if the senior identifies multiple.
 - If a fix is proposed: it must actually work. A command missing required parameters or targeting the wrong resource is NOT equivalent, even if the diagnosis is correct.
 
-## May Differ
+### May Differ
 
 - Wording, formatting, level of detail, or method of investigation.
 - Console URLs, dashboard links, retention periods, region names when obvious.
 - Additional correct information beyond the reference.
 - Formatting details of identifiers when the resource is unambiguously identified.
 
-## Fail If
+### Fail If
 
 1. Wrong verdict (broken vs working).
 2. Wrong root cause that would not explain or fix the problem.
@@ -34,19 +36,27 @@ The answers are EQUIVALENT if a practitioner following the junior's answer would
 5. Missing a primary root cause the senior identified.
 6. Introduces false claims about the infrastructure that would mislead a practitioner. Minor imprecisions in non-actionable details do not count.
 
-## Clarifications
+### Clarifications
 
 - Omitting a detail is acceptable UNLESS it changes what action a practitioner would take.
 - Merely mentioning an approach is not the same as providing it as the solution.
 - Listing more resources than the reference says exist is NOT equivalent.
 - If the junior answers with a question and the senior gives an explicit answer, NOT equivalent.
 
-## Steps
+### Steps
 
 1. Read the instruction to understand what was asked.
 2. Identify what action a practitioner would take from the senior's answer.
 3. Check if the junior's answer leads to the same effective action.
 4. Check if any Fail condition applies.
 5. If same effective action and no fail condition: EQUIVALENT.
+
+## Per-Claim Grading
+
+This task's reference answer has been decomposed into the individual claims listed below. Score each claim independently, on its own merits -- whether the junior's answer covers other listed claims should not affect this one.
+
+- For each claim, judge whether the junior's answer in agent-output.txt supports it, allowing for differences in wording, formatting, or level of detail per the Must Match / May Differ / Fail If rules above.
+- A claim about a fix or remediation step is satisfied when the junior proposes an equivalent fix; a claim about a root cause is satisfied when the junior identifies an equivalent cause.
+- EXCEPTION: the claim named `no_extraneous_or_contradicting_facts` (if listed below) is judged differently from every other claim here -- follow its own description, which judges the answer as a WHOLE against the ENTIRE reference answer, not one isolated fact.
 
 {criteria}

--- a/tasks/serverless-apps/ecs-services-custom-configurations-check/tests/judge.toml
+++ b/tasks/serverless-apps/ecs-services-custom-configurations-check/tests/judge.toml
@@ -5,9 +5,34 @@ files = [
     "/tests/ground_truth.json",
 ]
 prompt_template = "judge_prompt.md"
-mode = "individual"
+mode = "batched"
 
 [[criterion]]
-name = "answers_equivalent"
-description = "Are the junior engineer's findings equivalent to the senior engineer's reference answer per the rubric?"
+name = "serverless_apps_ecs_us_east_1_ecsservicename_has"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): {{serverless-apps-ECS-us-east-1-EcsServiceName}} has a desired task count of 2"
+type = "binary"
+
+[[criterion]]
+name = "serverless_apps_ecs_us_east_1_ecsservicename_has_2"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): {{serverless-apps-ECS-us-east-1-EcsServiceName}} has public IP assignment enabled"
+type = "binary"
+
+[[criterion]]
+name = "serverless_apps_ecs_us_east_1_ecsservicename_use"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): {{serverless-apps-ECS-us-east-1-EcsServiceName}} uses a Windows Server 2019 Full platform, and this is a non-default/customized setting (Fargate's default operating system family is Linux). The instruction specifically asks to check for custom/non-default configurations, so merely stating the platform as a neutral fact (e.g. listing it only under a 'current state' heading, with no indication it is a deviation from default) does NOT satisfy this claim -- credit it only if the junior's answer identifies or treats this platform choice as a customization/deviation from default."
+type = "binary"
+
+[[criterion]]
+name = "serverless_apps_ecs_us_east_1_ecsservicename_has_3"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): {{serverless-apps-ECS-us-east-1-EcsServiceName}} has a health check grace period of 60 seconds"
+type = "binary"
+
+[[criterion]]
+name = "serverless_apps_ecs_us_east_1_ecsservicename_has_4"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): {{serverless-apps-ECS-us-east-1-EcsServiceName}} has minimumHealthyPercent set to 50"
+type = "binary"
+
+[[criterion]]
+name = "no_extraneous_or_contradicting_facts"
+description = "Per the rubric's Fail-If and Clarifications rules, does the junior engineer's answer AVOID both of the following: (1) stating any fact that contradicts the reference answer's stated infrastructure state (e.g. a different count, the wrong resource, an opposite status), and (2) claiming the existence of additional resources, findings, or facts beyond what the reference answer states, in a way that would mislead a practitioner into a different conclusion or action. Judge the junior's answer as a whole against the entire reference answer for this, not any single claim. Answer 'yes' if the junior's answer contains no such contradiction or unsupported extra claim; answer 'no' if it does."
 type = "binary"

--- a/tasks/serverless-apps/ecs-services-custom-configurations-check/tests/judge_prompt.md
+++ b/tasks/serverless-apps/ecs-services-custom-configurations-check/tests/judge_prompt.md
@@ -7,25 +7,27 @@ You will be shown two files in the user message:
    - `instruction`: the task itself (what the user asked).
    - `expected_answer`: the senior engineer's reference answer.
 
-## Evaluation Standard
+## General Guidance
+
+### Evaluation Standard
 
 The answers are EQUIVALENT if a practitioner following the junior's answer would reach the same conclusion and take the same effective action as someone following the senior's answer.
 
-## Must Match
+### Must Match
 
 - The primary root cause or diagnosis.
 - The overall verdict (broken/working, how many, which resource).
 - All distinct root causes if the senior identifies multiple.
 - If a fix is proposed: it must actually work. A command missing required parameters or targeting the wrong resource is NOT equivalent, even if the diagnosis is correct.
 
-## May Differ
+### May Differ
 
 - Wording, formatting, level of detail, or method of investigation.
 - Console URLs, dashboard links, retention periods, region names when obvious.
 - Additional correct information beyond the reference.
 - Formatting details of identifiers when the resource is unambiguously identified.
 
-## Fail If
+### Fail If
 
 1. Wrong verdict (broken vs working).
 2. Wrong root cause that would not explain or fix the problem.
@@ -34,19 +36,27 @@ The answers are EQUIVALENT if a practitioner following the junior's answer would
 5. Missing a primary root cause the senior identified.
 6. Introduces false claims about the infrastructure that would mislead a practitioner. Minor imprecisions in non-actionable details do not count.
 
-## Clarifications
+### Clarifications
 
 - Omitting a detail is acceptable UNLESS it changes what action a practitioner would take.
 - Merely mentioning an approach is not the same as providing it as the solution.
 - Listing more resources than the reference says exist is NOT equivalent.
 - If the junior answers with a question and the senior gives an explicit answer, NOT equivalent.
 
-## Steps
+### Steps
 
 1. Read the instruction to understand what was asked.
 2. Identify what action a practitioner would take from the senior's answer.
 3. Check if the junior's answer leads to the same effective action.
 4. Check if any Fail condition applies.
 5. If same effective action and no fail condition: EQUIVALENT.
+
+## Per-Claim Grading
+
+This task's reference answer has been decomposed into the individual claims listed below. Score each claim independently, on its own merits -- whether the junior's answer covers other listed claims should not affect this one.
+
+- For each claim, judge whether the junior's answer in agent-output.txt supports it, allowing for differences in wording, formatting, or level of detail per the Must Match / May Differ / Fail If rules above.
+- A claim about a fix or remediation step is satisfied when the junior proposes an equivalent fix; a claim about a root cause is satisfied when the junior identifies an equivalent cause.
+- EXCEPTION: the claim named `no_extraneous_or_contradicting_facts` (if listed below) is judged differently from every other claim here -- follow its own description, which judges the answer as a WHOLE against the ENTIRE reference answer, not one isolated fact.
 
 {criteria}

--- a/tasks/serverless-apps/ecs-services-ecr-access-check/tests/judge.toml
+++ b/tasks/serverless-apps/ecs-services-ecr-access-check/tests/judge.toml
@@ -5,9 +5,19 @@ files = [
     "/tests/ground_truth.json",
 ]
 prompt_template = "judge_prompt.md"
-mode = "individual"
+mode = "batched"
 
 [[criterion]]
-name = "answers_equivalent"
-description = "Are the junior engineer's findings equivalent to the senior engineer's reference answer per the rubric?"
+name = "the_container_image_used_by_the_service_in_the_e"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The container image used by the service in the ECS cluster {{serverless-apps-ECS-us-east-1-EcsClusterName}} is mcr.microsoft.com/windows/servercore/iis:windowsservercore-ltsc2019"
+type = "binary"
+
+[[criterion]]
+name = "the_service_cannot_access_the_ecr_repository_my_"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The service cannot access the ECR repository my-ecr-repo"
+type = "binary"
+
+[[criterion]]
+name = "no_extraneous_or_contradicting_facts"
+description = "Per the rubric's Fail-If and Clarifications rules, does the junior engineer's answer AVOID both of the following: (1) stating any fact that contradicts the reference answer's stated infrastructure state (e.g. a different count, the wrong resource, an opposite status), and (2) claiming the existence of additional resources, findings, or facts beyond what the reference answer states, in a way that would mislead a practitioner into a different conclusion or action. Judge the junior's answer as a whole against the entire reference answer for this, not any single claim. Answer 'yes' if the junior's answer contains no such contradiction or unsupported extra claim; answer 'no' if it does."
 type = "binary"

--- a/tasks/serverless-apps/ecs-services-ecr-access-check/tests/judge_prompt.md
+++ b/tasks/serverless-apps/ecs-services-ecr-access-check/tests/judge_prompt.md
@@ -7,25 +7,27 @@ You will be shown two files in the user message:
    - `instruction`: the task itself (what the user asked).
    - `expected_answer`: the senior engineer's reference answer.
 
-## Evaluation Standard
+## General Guidance
+
+### Evaluation Standard
 
 The answers are EQUIVALENT if a practitioner following the junior's answer would reach the same conclusion and take the same effective action as someone following the senior's answer.
 
-## Must Match
+### Must Match
 
 - The primary root cause or diagnosis.
 - The overall verdict (broken/working, how many, which resource).
 - All distinct root causes if the senior identifies multiple.
 - If a fix is proposed: it must actually work. A command missing required parameters or targeting the wrong resource is NOT equivalent, even if the diagnosis is correct.
 
-## May Differ
+### May Differ
 
 - Wording, formatting, level of detail, or method of investigation.
 - Console URLs, dashboard links, retention periods, region names when obvious.
 - Additional correct information beyond the reference.
 - Formatting details of identifiers when the resource is unambiguously identified.
 
-## Fail If
+### Fail If
 
 1. Wrong verdict (broken vs working).
 2. Wrong root cause that would not explain or fix the problem.
@@ -34,19 +36,27 @@ The answers are EQUIVALENT if a practitioner following the junior's answer would
 5. Missing a primary root cause the senior identified.
 6. Introduces false claims about the infrastructure that would mislead a practitioner. Minor imprecisions in non-actionable details do not count.
 
-## Clarifications
+### Clarifications
 
 - Omitting a detail is acceptable UNLESS it changes what action a practitioner would take.
 - Merely mentioning an approach is not the same as providing it as the solution.
 - Listing more resources than the reference says exist is NOT equivalent.
 - If the junior answers with a question and the senior gives an explicit answer, NOT equivalent.
 
-## Steps
+### Steps
 
 1. Read the instruction to understand what was asked.
 2. Identify what action a practitioner would take from the senior's answer.
 3. Check if the junior's answer leads to the same effective action.
 4. Check if any Fail condition applies.
 5. If same effective action and no fail condition: EQUIVALENT.
+
+## Per-Claim Grading
+
+This task's reference answer has been decomposed into the individual claims listed below. Score each claim independently, on its own merits -- whether the junior's answer covers other listed claims should not affect this one.
+
+- For each claim, judge whether the junior's answer in agent-output.txt supports it, allowing for differences in wording, formatting, or level of detail per the Must Match / May Differ / Fail If rules above.
+- A claim about a fix or remediation step is satisfied when the junior proposes an equivalent fix; a claim about a root cause is satisfied when the junior identifies an equivalent cause.
+- EXCEPTION: the claim named `no_extraneous_or_contradicting_facts` (if listed below) is judged differently from every other claim here -- follow its own description, which judges the answer as a WHOLE against the ENTIRE reference answer, not one isolated fact.
 
 {criteria}

--- a/tasks/serverless-apps/find-lambda-functions-tagged-blueprint/tests/judge.toml
+++ b/tasks/serverless-apps/find-lambda-functions-tagged-blueprint/tests/judge.toml
@@ -5,9 +5,14 @@ files = [
     "/tests/ground_truth.json",
 ]
 prompt_template = "judge_prompt.md"
-mode = "individual"
+mode = "batched"
 
 [[criterion]]
-name = "answers_equivalent"
-description = "Are the junior engineer's findings equivalent to the senior engineer's reference answer per the rubric?"
+name = "the_serverless_apps_lambdamisc_us_east_1_taggedl"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The {{serverless-apps-LambdaMisc-us-east-1-TaggedLambdaName}} lambda function has the 'lambda-console:blueprint' tag."
+type = "binary"
+
+[[criterion]]
+name = "no_extraneous_or_contradicting_facts"
+description = "Per the rubric's Fail-If and Clarifications rules, does the junior engineer's answer AVOID both of the following: (1) stating any fact that contradicts the reference answer's stated infrastructure state (e.g. a different count, the wrong resource, an opposite status), and (2) claiming the existence of additional resources, findings, or facts beyond what the reference answer states, in a way that would mislead a practitioner into a different conclusion or action. Judge the junior's answer as a whole against the entire reference answer for this, not any single claim. Answer 'yes' if the junior's answer contains no such contradiction or unsupported extra claim; answer 'no' if it does."
 type = "binary"

--- a/tasks/serverless-apps/find-lambda-functions-tagged-blueprint/tests/judge_prompt.md
+++ b/tasks/serverless-apps/find-lambda-functions-tagged-blueprint/tests/judge_prompt.md
@@ -7,25 +7,27 @@ You will be shown two files in the user message:
    - `instruction`: the task itself (what the user asked).
    - `expected_answer`: the senior engineer's reference answer.
 
-## Evaluation Standard
+## General Guidance
+
+### Evaluation Standard
 
 The answers are EQUIVALENT if a practitioner following the junior's answer would reach the same conclusion and take the same effective action as someone following the senior's answer.
 
-## Must Match
+### Must Match
 
 - The primary root cause or diagnosis.
 - The overall verdict (broken/working, how many, which resource).
 - All distinct root causes if the senior identifies multiple.
 - If a fix is proposed: it must actually work. A command missing required parameters or targeting the wrong resource is NOT equivalent, even if the diagnosis is correct.
 
-## May Differ
+### May Differ
 
 - Wording, formatting, level of detail, or method of investigation.
 - Console URLs, dashboard links, retention periods, region names when obvious.
 - Additional correct information beyond the reference.
 - Formatting details of identifiers when the resource is unambiguously identified.
 
-## Fail If
+### Fail If
 
 1. Wrong verdict (broken vs working).
 2. Wrong root cause that would not explain or fix the problem.
@@ -34,19 +36,27 @@ The answers are EQUIVALENT if a practitioner following the junior's answer would
 5. Missing a primary root cause the senior identified.
 6. Introduces false claims about the infrastructure that would mislead a practitioner. Minor imprecisions in non-actionable details do not count.
 
-## Clarifications
+### Clarifications
 
 - Omitting a detail is acceptable UNLESS it changes what action a practitioner would take.
 - Merely mentioning an approach is not the same as providing it as the solution.
 - Listing more resources than the reference says exist is NOT equivalent.
 - If the junior answers with a question and the senior gives an explicit answer, NOT equivalent.
 
-## Steps
+### Steps
 
 1. Read the instruction to understand what was asked.
 2. Identify what action a practitioner would take from the senior's answer.
 3. Check if the junior's answer leads to the same effective action.
 4. Check if any Fail condition applies.
 5. If same effective action and no fail condition: EQUIVALENT.
+
+## Per-Claim Grading
+
+This task's reference answer has been decomposed into the individual claims listed below. Score each claim independently, on its own merits -- whether the junior's answer covers other listed claims should not affect this one.
+
+- For each claim, judge whether the junior's answer in agent-output.txt supports it, allowing for differences in wording, formatting, or level of detail per the Must Match / May Differ / Fail If rules above.
+- A claim about a fix or remediation step is satisfied when the junior proposes an equivalent fix; a claim about a root cause is satisfied when the junior identifies an equivalent cause.
+- EXCEPTION: the claim named `no_extraneous_or_contradicting_facts` (if listed below) is judged differently from every other claim here -- follow its own description, which judges the answer as a WHOLE against the ENTIRE reference answer, not one isolated fact.
 
 {criteria}

--- a/tasks/serverless-apps/find-metric-streams-excluding-namespace/tests/judge.toml
+++ b/tasks/serverless-apps/find-metric-streams-excluding-namespace/tests/judge.toml
@@ -5,9 +5,14 @@ files = [
     "/tests/ground_truth.json",
 ]
 prompt_template = "judge_prompt.md"
-mode = "individual"
+mode = "batched"
 
 [[criterion]]
-name = "answers_equivalent"
-description = "Are the junior engineer's findings equivalent to the senior engineer's reference answer per the rubric?"
+name = "the_metric_stream_serverless_apps_monitoring_us_"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The metric stream {{serverless-apps-Monitoring-us-east-1-MetricStreamName}} excludes the metrics CPUUtilization, NetworkIn, NetworkOut, DiskReadBytes, and DiskWriteBytes from the AWS/EC2 namespace."
+type = "binary"
+
+[[criterion]]
+name = "no_extraneous_or_contradicting_facts"
+description = "Per the rubric's Fail-If and Clarifications rules, does the junior engineer's answer AVOID both of the following: (1) stating any fact that contradicts the reference answer's stated infrastructure state (e.g. a different count, the wrong resource, an opposite status), and (2) claiming the existence of additional resources, findings, or facts beyond what the reference answer states, in a way that would mislead a practitioner into a different conclusion or action. Judge the junior's answer as a whole against the entire reference answer for this, not any single claim. Answer 'yes' if the junior's answer contains no such contradiction or unsupported extra claim; answer 'no' if it does. IMPORTANT: this account has a second metric stream that only uses include filters (no exclude filters). The instruction only asks whether any stream excludes metrics from a namespace, so the reference answer names just the one stream that does. If the junior's answer also mentions the second stream and correctly notes it has no exclusion filters / uses inclusion filters instead, that is NOT an extraneous or contradicting claim -- it is an accurate observation that does not change the answer to the question asked, and must not cause this criterion to fail."
 type = "binary"

--- a/tasks/serverless-apps/find-metric-streams-excluding-namespace/tests/judge_prompt.md
+++ b/tasks/serverless-apps/find-metric-streams-excluding-namespace/tests/judge_prompt.md
@@ -7,25 +7,27 @@ You will be shown two files in the user message:
    - `instruction`: the task itself (what the user asked).
    - `expected_answer`: the senior engineer's reference answer.
 
-## Evaluation Standard
+## General Guidance
+
+### Evaluation Standard
 
 The answers are EQUIVALENT if a practitioner following the junior's answer would reach the same conclusion and take the same effective action as someone following the senior's answer.
 
-## Must Match
+### Must Match
 
 - The primary root cause or diagnosis.
 - The overall verdict (broken/working, how many, which resource).
 - All distinct root causes if the senior identifies multiple.
 - If a fix is proposed: it must actually work. A command missing required parameters or targeting the wrong resource is NOT equivalent, even if the diagnosis is correct.
 
-## May Differ
+### May Differ
 
 - Wording, formatting, level of detail, or method of investigation.
 - Console URLs, dashboard links, retention periods, region names when obvious.
 - Additional correct information beyond the reference.
 - Formatting details of identifiers when the resource is unambiguously identified.
 
-## Fail If
+### Fail If
 
 1. Wrong verdict (broken vs working).
 2. Wrong root cause that would not explain or fix the problem.
@@ -34,19 +36,27 @@ The answers are EQUIVALENT if a practitioner following the junior's answer would
 5. Missing a primary root cause the senior identified.
 6. Introduces false claims about the infrastructure that would mislead a practitioner. Minor imprecisions in non-actionable details do not count.
 
-## Clarifications
+### Clarifications
 
 - Omitting a detail is acceptable UNLESS it changes what action a practitioner would take.
 - Merely mentioning an approach is not the same as providing it as the solution.
 - Listing more resources than the reference says exist is NOT equivalent.
 - If the junior answers with a question and the senior gives an explicit answer, NOT equivalent.
 
-## Steps
+### Steps
 
 1. Read the instruction to understand what was asked.
 2. Identify what action a practitioner would take from the senior's answer.
 3. Check if the junior's answer leads to the same effective action.
 4. Check if any Fail condition applies.
 5. If same effective action and no fail condition: EQUIVALENT.
+
+## Per-Claim Grading
+
+This task's reference answer has been decomposed into the individual claims listed below. Score each claim independently, on its own merits -- whether the junior's answer covers other listed claims should not affect this one.
+
+- For each claim, judge whether the junior's answer in agent-output.txt supports it, allowing for differences in wording, formatting, or level of detail per the Must Match / May Differ / Fail If rules above.
+- A claim about a fix or remediation step is satisfied when the junior proposes an equivalent fix; a claim about a root cause is satisfied when the junior identifies an equivalent cause.
+- EXCEPTION: the claim named `no_extraneous_or_contradicting_facts` (if listed below) is judged differently from every other claim here -- follow its own description, which judges the answer as a WHOLE against the ENTIRE reference answer, not one isolated fact.
 
 {criteria}

--- a/tasks/serverless-apps/find-sns-triggered-lambda-functions/tests/judge.toml
+++ b/tasks/serverless-apps/find-sns-triggered-lambda-functions/tests/judge.toml
@@ -5,9 +5,14 @@ files = [
     "/tests/ground_truth.json",
 ]
 prompt_template = "judge_prompt.md"
-mode = "individual"
+mode = "batched"
 
 [[criterion]]
-name = "answers_equivalent"
-description = "Are the junior engineer's findings equivalent to the senior engineer's reference answer per the rubric?"
+name = "serverless_apps_lambdamisc_us_east_1_connectedla"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): {{serverless-apps-LambdaMisc-us-east-1-ConnectedLambdaName}} is triggered by SNS topic {{serverless-apps-LambdaMisc-us-east-1-ConnectedSNSTopicName}}"
+type = "binary"
+
+[[criterion]]
+name = "no_extraneous_or_contradicting_facts"
+description = "Per the rubric's Fail-If and Clarifications rules, does the junior engineer's answer AVOID both of the following: (1) stating any fact that contradicts the reference answer's stated infrastructure state (e.g. a different count, the wrong resource, an opposite status), and (2) claiming the existence of additional resources, findings, or facts beyond what the reference answer states, in a way that would mislead a practitioner into a different conclusion or action. Judge the junior's answer as a whole against the entire reference answer for this, not any single claim. Answer 'yes' if the junior's answer contains no such contradiction or unsupported extra claim; answer 'no' if it does."
 type = "binary"

--- a/tasks/serverless-apps/find-sns-triggered-lambda-functions/tests/judge_prompt.md
+++ b/tasks/serverless-apps/find-sns-triggered-lambda-functions/tests/judge_prompt.md
@@ -7,25 +7,27 @@ You will be shown two files in the user message:
    - `instruction`: the task itself (what the user asked).
    - `expected_answer`: the senior engineer's reference answer.
 
-## Evaluation Standard
+## General Guidance
+
+### Evaluation Standard
 
 The answers are EQUIVALENT if a practitioner following the junior's answer would reach the same conclusion and take the same effective action as someone following the senior's answer.
 
-## Must Match
+### Must Match
 
 - The primary root cause or diagnosis.
 - The overall verdict (broken/working, how many, which resource).
 - All distinct root causes if the senior identifies multiple.
 - If a fix is proposed: it must actually work. A command missing required parameters or targeting the wrong resource is NOT equivalent, even if the diagnosis is correct.
 
-## May Differ
+### May Differ
 
 - Wording, formatting, level of detail, or method of investigation.
 - Console URLs, dashboard links, retention periods, region names when obvious.
 - Additional correct information beyond the reference.
 - Formatting details of identifiers when the resource is unambiguously identified.
 
-## Fail If
+### Fail If
 
 1. Wrong verdict (broken vs working).
 2. Wrong root cause that would not explain or fix the problem.
@@ -34,19 +36,27 @@ The answers are EQUIVALENT if a practitioner following the junior's answer would
 5. Missing a primary root cause the senior identified.
 6. Introduces false claims about the infrastructure that would mislead a practitioner. Minor imprecisions in non-actionable details do not count.
 
-## Clarifications
+### Clarifications
 
 - Omitting a detail is acceptable UNLESS it changes what action a practitioner would take.
 - Merely mentioning an approach is not the same as providing it as the solution.
 - Listing more resources than the reference says exist is NOT equivalent.
 - If the junior answers with a question and the senior gives an explicit answer, NOT equivalent.
 
-## Steps
+### Steps
 
 1. Read the instruction to understand what was asked.
 2. Identify what action a practitioner would take from the senior's answer.
 3. Check if the junior's answer leads to the same effective action.
 4. Check if any Fail condition applies.
 5. If same effective action and no fail condition: EQUIVALENT.
+
+## Per-Claim Grading
+
+This task's reference answer has been decomposed into the individual claims listed below. Score each claim independently, on its own merits -- whether the junior's answer covers other listed claims should not affect this one.
+
+- For each claim, judge whether the junior's answer in agent-output.txt supports it, allowing for differences in wording, formatting, or level of detail per the Must Match / May Differ / Fail If rules above.
+- A claim about a fix or remediation step is satisfied when the junior proposes an equivalent fix; a claim about a root cause is satisfied when the junior identifies an equivalent cause.
+- EXCEPTION: the claim named `no_extraneous_or_contradicting_facts` (if listed below) is judged differently from every other claim here -- follow its own description, which judges the answer as a WHOLE against the ENTIRE reference answer, not one isolated fact.
 
 {criteria}

--- a/tasks/serverless-apps/list-s-buckets-website-hosting/tests/judge.toml
+++ b/tasks/serverless-apps/list-s-buckets-website-hosting/tests/judge.toml
@@ -5,9 +5,19 @@ files = [
     "/tests/ground_truth.json",
 ]
 prompt_template = "judge_prompt.md"
-mode = "individual"
+mode = "batched"
 
 [[criterion]]
-name = "answers_equivalent"
-description = "Are the junior engineer's findings equivalent to the senior engineer's reference answer per the rubric?"
+name = "serverless_apps_s3storage_us_east_1_websitehosti"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): {{serverless-apps-S3Storage-us-east-1-WebsiteHostingBucketName}} has website hosting enabled"
+type = "binary"
+
+[[criterion]]
+name = "one_s3_bucket_in_your_account_has_website_hostin"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): One S3 bucket in your account has website hosting enabled"
+type = "binary"
+
+[[criterion]]
+name = "no_extraneous_or_contradicting_facts"
+description = "Per the rubric's Fail-If and Clarifications rules, does the junior engineer's answer AVOID both of the following: (1) stating any fact that contradicts the reference answer's stated infrastructure state (e.g. a different count, the wrong resource, an opposite status), and (2) claiming the existence of additional resources, findings, or facts beyond what the reference answer states, in a way that would mislead a practitioner into a different conclusion or action. Judge the junior's answer as a whole against the entire reference answer for this, not any single claim. Answer 'yes' if the junior's answer contains no such contradiction or unsupported extra claim; answer 'no' if it does."
 type = "binary"

--- a/tasks/serverless-apps/list-s-buckets-website-hosting/tests/judge_prompt.md
+++ b/tasks/serverless-apps/list-s-buckets-website-hosting/tests/judge_prompt.md
@@ -7,25 +7,27 @@ You will be shown two files in the user message:
    - `instruction`: the task itself (what the user asked).
    - `expected_answer`: the senior engineer's reference answer.
 
-## Evaluation Standard
+## General Guidance
+
+### Evaluation Standard
 
 The answers are EQUIVALENT if a practitioner following the junior's answer would reach the same conclusion and take the same effective action as someone following the senior's answer.
 
-## Must Match
+### Must Match
 
 - The primary root cause or diagnosis.
 - The overall verdict (broken/working, how many, which resource).
 - All distinct root causes if the senior identifies multiple.
 - If a fix is proposed: it must actually work. A command missing required parameters or targeting the wrong resource is NOT equivalent, even if the diagnosis is correct.
 
-## May Differ
+### May Differ
 
 - Wording, formatting, level of detail, or method of investigation.
 - Console URLs, dashboard links, retention periods, region names when obvious.
 - Additional correct information beyond the reference.
 - Formatting details of identifiers when the resource is unambiguously identified.
 
-## Fail If
+### Fail If
 
 1. Wrong verdict (broken vs working).
 2. Wrong root cause that would not explain or fix the problem.
@@ -34,19 +36,27 @@ The answers are EQUIVALENT if a practitioner following the junior's answer would
 5. Missing a primary root cause the senior identified.
 6. Introduces false claims about the infrastructure that would mislead a practitioner. Minor imprecisions in non-actionable details do not count.
 
-## Clarifications
+### Clarifications
 
 - Omitting a detail is acceptable UNLESS it changes what action a practitioner would take.
 - Merely mentioning an approach is not the same as providing it as the solution.
 - Listing more resources than the reference says exist is NOT equivalent.
 - If the junior answers with a question and the senior gives an explicit answer, NOT equivalent.
 
-## Steps
+### Steps
 
 1. Read the instruction to understand what was asked.
 2. Identify what action a practitioner would take from the senior's answer.
 3. Check if the junior's answer leads to the same effective action.
 4. Check if any Fail condition applies.
 5. If same effective action and no fail condition: EQUIVALENT.
+
+## Per-Claim Grading
+
+This task's reference answer has been decomposed into the individual claims listed below. Score each claim independently, on its own merits -- whether the junior's answer covers other listed claims should not affect this one.
+
+- For each claim, judge whether the junior's answer in agent-output.txt supports it, allowing for differences in wording, formatting, or level of detail per the Must Match / May Differ / Fail If rules above.
+- A claim about a fix or remediation step is satisfied when the junior proposes an equivalent fix; a claim about a root cause is satisfied when the junior identifies an equivalent cause.
+- EXCEPTION: the claim named `no_extraneous_or_contradicting_facts` (if listed below) is judged differently from every other claim here -- follow its own description, which judges the answer as a WHOLE against the ENTIRE reference answer, not one isolated fact.
 
 {criteria}

--- a/tasks/serverless-apps/list-s-buckets-with-metrics-tag-filters/tests/judge.toml
+++ b/tasks/serverless-apps/list-s-buckets-with-metrics-tag-filters/tests/judge.toml
@@ -5,9 +5,14 @@ files = [
     "/tests/ground_truth.json",
 ]
 prompt_template = "judge_prompt.md"
-mode = "individual"
+mode = "batched"
 
 [[criterion]]
-name = "answers_equivalent"
-description = "Are the junior engineer's findings equivalent to the senior engineer's reference answer per the rubric?"
+name = "the_bucket_serverless_apps_s3storage_us_east_1_m"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The bucket {{serverless-apps-S3Storage-us-east-1-MetricsBucketName}} uses tag filters in its metrics configuration."
+type = "binary"
+
+[[criterion]]
+name = "no_extraneous_or_contradicting_facts"
+description = "Per the rubric's Fail-If and Clarifications rules, does the junior engineer's answer AVOID both of the following: (1) stating any fact that contradicts the reference answer's stated infrastructure state (e.g. a different count, the wrong resource, an opposite status), and (2) claiming the existence of additional resources, findings, or facts beyond what the reference answer states, in a way that would mislead a practitioner into a different conclusion or action. Judge the junior's answer as a whole against the entire reference answer for this, not any single claim. Answer 'yes' if the junior's answer contains no such contradiction or unsupported extra claim; answer 'no' if it does."
 type = "binary"

--- a/tasks/serverless-apps/list-s-buckets-with-metrics-tag-filters/tests/judge_prompt.md
+++ b/tasks/serverless-apps/list-s-buckets-with-metrics-tag-filters/tests/judge_prompt.md
@@ -7,25 +7,27 @@ You will be shown two files in the user message:
    - `instruction`: the task itself (what the user asked).
    - `expected_answer`: the senior engineer's reference answer.
 
-## Evaluation Standard
+## General Guidance
+
+### Evaluation Standard
 
 The answers are EQUIVALENT if a practitioner following the junior's answer would reach the same conclusion and take the same effective action as someone following the senior's answer.
 
-## Must Match
+### Must Match
 
 - The primary root cause or diagnosis.
 - The overall verdict (broken/working, how many, which resource).
 - All distinct root causes if the senior identifies multiple.
 - If a fix is proposed: it must actually work. A command missing required parameters or targeting the wrong resource is NOT equivalent, even if the diagnosis is correct.
 
-## May Differ
+### May Differ
 
 - Wording, formatting, level of detail, or method of investigation.
 - Console URLs, dashboard links, retention periods, region names when obvious.
 - Additional correct information beyond the reference.
 - Formatting details of identifiers when the resource is unambiguously identified.
 
-## Fail If
+### Fail If
 
 1. Wrong verdict (broken vs working).
 2. Wrong root cause that would not explain or fix the problem.
@@ -34,19 +36,27 @@ The answers are EQUIVALENT if a practitioner following the junior's answer would
 5. Missing a primary root cause the senior identified.
 6. Introduces false claims about the infrastructure that would mislead a practitioner. Minor imprecisions in non-actionable details do not count.
 
-## Clarifications
+### Clarifications
 
 - Omitting a detail is acceptable UNLESS it changes what action a practitioner would take.
 - Merely mentioning an approach is not the same as providing it as the solution.
 - Listing more resources than the reference says exist is NOT equivalent.
 - If the junior answers with a question and the senior gives an explicit answer, NOT equivalent.
 
-## Steps
+### Steps
 
 1. Read the instruction to understand what was asked.
 2. Identify what action a practitioner would take from the senior's answer.
 3. Check if the junior's answer leads to the same effective action.
 4. Check if any Fail condition applies.
 5. If same effective action and no fail condition: EQUIVALENT.
+
+## Per-Claim Grading
+
+This task's reference answer has been decomposed into the individual claims listed below. Score each claim independently, on its own merits -- whether the junior's answer covers other listed claims should not affect this one.
+
+- For each claim, judge whether the junior's answer in agent-output.txt supports it, allowing for differences in wording, formatting, or level of detail per the Must Match / May Differ / Fail If rules above.
+- A claim about a fix or remediation step is satisfied when the junior proposes an equivalent fix; a claim about a root cause is satisfied when the junior identifies an equivalent cause.
+- EXCEPTION: the claim named `no_extraneous_or_contradicting_facts` (if listed below) is judged differently from every other claim here -- follow its own description, which judges the answer as a WHOLE against the ENTIRE reference answer, not one isolated fact.
 
 {criteria}

--- a/tasks/serverless-apps/list-s-cross-account-analytics-exports/tests/judge.toml
+++ b/tasks/serverless-apps/list-s-cross-account-analytics-exports/tests/judge.toml
@@ -5,9 +5,29 @@ files = [
     "/tests/ground_truth.json",
 ]
 prompt_template = "judge_prompt.md"
-mode = "individual"
+mode = "batched"
 
 [[criterion]]
-name = "answers_equivalent"
-description = "Are the junior engineer's findings equivalent to the senior engineer's reference answer per the rubric?"
+name = "there_is_an_analytics_configuration_named_testan"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): There is an analytics configuration named 'testAnalyticsConfiguration' on {{serverless-apps-S3Storage-us-east-1-AnalyticsBucketName}}"
+type = "binary"
+
+[[criterion]]
+name = "the_testanalyticsconfiguration_analytics_configu"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The 'testAnalyticsConfiguration' analytics configuration's S3BucketDestination sets BucketAccountId to 111122223333"
+type = "binary"
+
+[[criterion]]
+name = "111122223333_is_not_the_account_that_owns_the_so"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): 111122223333 is not the account that owns the source bucket {{serverless-apps-S3Storage-us-east-1-AnalyticsBucketName}}"
+type = "binary"
+
+[[criterion]]
+name = "testanalyticsconfiguration_on_serverless_apps_s3"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): 'testAnalyticsConfiguration' on {{serverless-apps-S3Storage-us-east-1-AnalyticsBucketName}} is the only analytics configuration that exports to a different account"
+type = "binary"
+
+[[criterion]]
+name = "no_extraneous_or_contradicting_facts"
+description = "Per the rubric's Fail-If and Clarifications rules, does the junior engineer's answer AVOID both of the following: (1) stating any fact that contradicts the reference answer's stated infrastructure state (e.g. a different count, the wrong resource, an opposite status), and (2) claiming the existence of additional resources, findings, or facts beyond what the reference answer states, in a way that would mislead a practitioner into a different conclusion or action. Judge the junior's answer as a whole against the entire reference answer for this, not any single claim. Answer 'yes' if the junior's answer contains no such contradiction or unsupported extra claim; answer 'no' if it does."
 type = "binary"

--- a/tasks/serverless-apps/list-s-cross-account-analytics-exports/tests/judge_prompt.md
+++ b/tasks/serverless-apps/list-s-cross-account-analytics-exports/tests/judge_prompt.md
@@ -7,25 +7,27 @@ You will be shown two files in the user message:
    - `instruction`: the task itself (what the user asked).
    - `expected_answer`: the senior engineer's reference answer.
 
-## Evaluation Standard
+## General Guidance
+
+### Evaluation Standard
 
 The answers are EQUIVALENT if a practitioner following the junior's answer would reach the same conclusion and take the same effective action as someone following the senior's answer.
 
-## Must Match
+### Must Match
 
 - The primary root cause or diagnosis.
 - The overall verdict (broken/working, how many, which resource).
 - All distinct root causes if the senior identifies multiple.
 - If a fix is proposed: it must actually work. A command missing required parameters or targeting the wrong resource is NOT equivalent, even if the diagnosis is correct.
 
-## May Differ
+### May Differ
 
 - Wording, formatting, level of detail, or method of investigation.
 - Console URLs, dashboard links, retention periods, region names when obvious.
 - Additional correct information beyond the reference.
 - Formatting details of identifiers when the resource is unambiguously identified.
 
-## Fail If
+### Fail If
 
 1. Wrong verdict (broken vs working).
 2. Wrong root cause that would not explain or fix the problem.
@@ -34,19 +36,27 @@ The answers are EQUIVALENT if a practitioner following the junior's answer would
 5. Missing a primary root cause the senior identified.
 6. Introduces false claims about the infrastructure that would mislead a practitioner. Minor imprecisions in non-actionable details do not count.
 
-## Clarifications
+### Clarifications
 
 - Omitting a detail is acceptable UNLESS it changes what action a practitioner would take.
 - Merely mentioning an approach is not the same as providing it as the solution.
 - Listing more resources than the reference says exist is NOT equivalent.
 - If the junior answers with a question and the senior gives an explicit answer, NOT equivalent.
 
-## Steps
+### Steps
 
 1. Read the instruction to understand what was asked.
 2. Identify what action a practitioner would take from the senior's answer.
 3. Check if the junior's answer leads to the same effective action.
 4. Check if any Fail condition applies.
 5. If same effective action and no fail condition: EQUIVALENT.
+
+## Per-Claim Grading
+
+This task's reference answer has been decomposed into the individual claims listed below. Score each claim independently, on its own merits -- whether the junior's answer covers other listed claims should not affect this one.
+
+- For each claim, judge whether the junior's answer in agent-output.txt supports it, allowing for differences in wording, formatting, or level of detail per the Must Match / May Differ / Fail If rules above.
+- A claim about a fix or remediation step is satisfied when the junior proposes an equivalent fix; a claim about a root cause is satisfied when the junior identifies an equivalent cause.
+- EXCEPTION: the claim named `no_extraneous_or_contradicting_facts` (if listed below) is judged differently from every other claim here -- follow its own description, which judges the answer as a WHOLE against the ENTIRE reference answer, not one isolated fact.
 
 {criteria}

--- a/tasks/serverless-apps/list-s-inventory-configs-with-prefix/tests/judge.toml
+++ b/tasks/serverless-apps/list-s-inventory-configs-with-prefix/tests/judge.toml
@@ -5,9 +5,24 @@ files = [
     "/tests/ground_truth.json",
 ]
 prompt_template = "judge_prompt.md"
-mode = "individual"
+mode = "batched"
 
 [[criterion]]
-name = "answers_equivalent"
-description = "Are the junior engineer's findings equivalent to the senior engineer's reference answer per the rubric?"
+name = "the_inventorybucketinventory0_configuration_on_b"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The 'InventoryBucketInventory0' configuration on bucket {{serverless-apps-S3Storage-us-east-1-InventoryBucketName}} has no Destination.S3BucketDestination.Prefix"
+type = "binary"
+
+[[criterion]]
+name = "the_inventorybucketinventory0_configuration_s_re"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The 'InventoryBucketInventory0' configuration's reports land at the destination bucket's root rather than under a prefix because it has no Destination.S3BucketDestination.Prefix"
+type = "binary"
+
+[[criterion]]
+name = "the_inventory_data_prefix_on_the_inventorybucket"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The 'inventory-data' prefix on the 'InventoryBucketInventory0' configuration is the source-side Filter.Prefix (which objects get inventoried), not a destination prefix"
+type = "binary"
+
+[[criterion]]
+name = "no_extraneous_or_contradicting_facts"
+description = "Per the rubric's Fail-If and Clarifications rules, does the junior engineer's answer AVOID both of the following: (1) stating any fact that contradicts the reference answer's stated infrastructure state (e.g. a different count, the wrong resource, an opposite status), and (2) claiming the existence of additional resources, findings, or facts beyond what the reference answer states, in a way that would mislead a practitioner into a different conclusion or action. Judge the junior's answer as a whole against the entire reference answer for this, not any single claim. Answer 'yes' if the junior's answer contains no such contradiction or unsupported extra claim; answer 'no' if it does."
 type = "binary"

--- a/tasks/serverless-apps/list-s-inventory-configs-with-prefix/tests/judge_prompt.md
+++ b/tasks/serverless-apps/list-s-inventory-configs-with-prefix/tests/judge_prompt.md
@@ -7,25 +7,27 @@ You will be shown two files in the user message:
    - `instruction`: the task itself (what the user asked).
    - `expected_answer`: the senior engineer's reference answer.
 
-## Evaluation Standard
+## General Guidance
+
+### Evaluation Standard
 
 The answers are EQUIVALENT if a practitioner following the junior's answer would reach the same conclusion and take the same effective action as someone following the senior's answer.
 
-## Must Match
+### Must Match
 
 - The primary root cause or diagnosis.
 - The overall verdict (broken/working, how many, which resource).
 - All distinct root causes if the senior identifies multiple.
 - If a fix is proposed: it must actually work. A command missing required parameters or targeting the wrong resource is NOT equivalent, even if the diagnosis is correct.
 
-## May Differ
+### May Differ
 
 - Wording, formatting, level of detail, or method of investigation.
 - Console URLs, dashboard links, retention periods, region names when obvious.
 - Additional correct information beyond the reference.
 - Formatting details of identifiers when the resource is unambiguously identified.
 
-## Fail If
+### Fail If
 
 1. Wrong verdict (broken vs working).
 2. Wrong root cause that would not explain or fix the problem.
@@ -34,19 +36,27 @@ The answers are EQUIVALENT if a practitioner following the junior's answer would
 5. Missing a primary root cause the senior identified.
 6. Introduces false claims about the infrastructure that would mislead a practitioner. Minor imprecisions in non-actionable details do not count.
 
-## Clarifications
+### Clarifications
 
 - Omitting a detail is acceptable UNLESS it changes what action a practitioner would take.
 - Merely mentioning an approach is not the same as providing it as the solution.
 - Listing more resources than the reference says exist is NOT equivalent.
 - If the junior answers with a question and the senior gives an explicit answer, NOT equivalent.
 
-## Steps
+### Steps
 
 1. Read the instruction to understand what was asked.
 2. Identify what action a practitioner would take from the senior's answer.
 3. Check if the junior's answer leads to the same effective action.
 4. Check if any Fail condition applies.
 5. If same effective action and no fail condition: EQUIVALENT.
+
+## Per-Claim Grading
+
+This task's reference answer has been decomposed into the individual claims listed below. Score each claim independently, on its own merits -- whether the junior's answer covers other listed claims should not affect this one.
+
+- For each claim, judge whether the junior's answer in agent-output.txt supports it, allowing for differences in wording, formatting, or level of detail per the Must Match / May Differ / Fail If rules above.
+- A claim about a fix or remediation step is satisfied when the junior proposes an equivalent fix; a claim about a root cause is satisfied when the junior identifies an equivalent cause.
+- EXCEPTION: the claim named `no_extraneous_or_contradicting_facts` (if listed below) is judged differently from every other claim here -- follow its own description, which judges the answer as a WHOLE against the ENTIRE reference answer, not one isolated fact.
 
 {criteria}

--- a/tasks/serverless-apps/s-bucket-metrics-tag-filter-check/tests/judge.toml
+++ b/tasks/serverless-apps/s-bucket-metrics-tag-filter-check/tests/judge.toml
@@ -5,9 +5,19 @@ files = [
     "/tests/ground_truth.json",
 ]
 prompt_template = "judge_prompt.md"
-mode = "individual"
+mode = "batched"
 
 [[criterion]]
-name = "answers_equivalent"
-description = "Are the junior engineer's findings equivalent to the senior engineer's reference answer per the rubric?"
+name = "the_bucket_serverless_apps_s3storage_us_east_1_m"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The bucket {{serverless-apps-S3Storage-us-east-1-MetricsBucketName}} uses tag filters."
+type = "binary"
+
+[[criterion]]
+name = "no_downstream_resources_consume_this_tag_filtere"
+description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): No downstream resources consume this tag-filtered metrics to create alarms."
+type = "binary"
+
+[[criterion]]
+name = "no_extraneous_or_contradicting_facts"
+description = "Per the rubric's Fail-If and Clarifications rules, does the junior engineer's answer AVOID both of the following: (1) stating any fact that contradicts the reference answer's stated infrastructure state (e.g. a different count, the wrong resource, an opposite status), and (2) claiming the existence of additional resources, findings, or facts beyond what the reference answer states, in a way that would mislead a practitioner into a different conclusion or action. Judge the junior's answer as a whole against the entire reference answer for this, not any single claim. Answer 'yes' if the junior's answer contains no such contradiction or unsupported extra claim; answer 'no' if it does."
 type = "binary"

--- a/tasks/serverless-apps/s-bucket-metrics-tag-filter-check/tests/judge_prompt.md
+++ b/tasks/serverless-apps/s-bucket-metrics-tag-filter-check/tests/judge_prompt.md
@@ -7,25 +7,27 @@ You will be shown two files in the user message:
    - `instruction`: the task itself (what the user asked).
    - `expected_answer`: the senior engineer's reference answer.
 
-## Evaluation Standard
+## General Guidance
+
+### Evaluation Standard
 
 The answers are EQUIVALENT if a practitioner following the junior's answer would reach the same conclusion and take the same effective action as someone following the senior's answer.
 
-## Must Match
+### Must Match
 
 - The primary root cause or diagnosis.
 - The overall verdict (broken/working, how many, which resource).
 - All distinct root causes if the senior identifies multiple.
 - If a fix is proposed: it must actually work. A command missing required parameters or targeting the wrong resource is NOT equivalent, even if the diagnosis is correct.
 
-## May Differ
+### May Differ
 
 - Wording, formatting, level of detail, or method of investigation.
 - Console URLs, dashboard links, retention periods, region names when obvious.
 - Additional correct information beyond the reference.
 - Formatting details of identifiers when the resource is unambiguously identified.
 
-## Fail If
+### Fail If
 
 1. Wrong verdict (broken vs working).
 2. Wrong root cause that would not explain or fix the problem.
@@ -34,19 +36,27 @@ The answers are EQUIVALENT if a practitioner following the junior's answer would
 5. Missing a primary root cause the senior identified.
 6. Introduces false claims about the infrastructure that would mislead a practitioner. Minor imprecisions in non-actionable details do not count.
 
-## Clarifications
+### Clarifications
 
 - Omitting a detail is acceptable UNLESS it changes what action a practitioner would take.
 - Merely mentioning an approach is not the same as providing it as the solution.
 - Listing more resources than the reference says exist is NOT equivalent.
 - If the junior answers with a question and the senior gives an explicit answer, NOT equivalent.
 
-## Steps
+### Steps
 
 1. Read the instruction to understand what was asked.
 2. Identify what action a practitioner would take from the senior's answer.
 3. Check if the junior's answer leads to the same effective action.
 4. Check if any Fail condition applies.
 5. If same effective action and no fail condition: EQUIVALENT.
+
+## Per-Claim Grading
+
+This task's reference answer has been decomposed into the individual claims listed below. Score each claim independently, on its own merits -- whether the junior's answer covers other listed claims should not affect this one.
+
+- For each claim, judge whether the junior's answer in agent-output.txt supports it, allowing for differences in wording, formatting, or level of detail per the Must Match / May Differ / Fail If rules above.
+- A claim about a fix or remediation step is satisfied when the junior proposes an equivalent fix; a claim about a root cause is satisfied when the junior identifies an equivalent cause.
+- EXCEPTION: the claim named `no_extraneous_or_contradicting_facts` (if listed below) is judged differently from every other claim here -- follow its own description, which judges the answer as a WHOLE against the ENTIRE reference answer, not one isolated fact.
 
 {criteria}


### PR DESCRIPTION
## Files changed

**86 files.** All scoped to `tasks/databases-and-storage/` and `tasks/serverless-apps/` — the 43 basic-tier introspection tasks (30 databases-and-storage + 13 serverless-apps). No shared/common files are touched; the common `resolve_placeholders.py`/`sync.sh` fixes already landed with the quickstart PR.

**Scope: basic tier only (43 tasks, 86 files)**

| File | Per task | Purpose | Change |
|---|---|---|---|
| `tests/judge.toml` | 43 | Judge configuration and grading criteria | Replaced the single holistic criterion with decomposed per-claim criteria plus an anti-hallucination catch-all |
| `tests/judge_prompt.md` | 43 | Instructions given to the judge model | Reorganized into a general-guidance section and a per-claim-grading section; no change to the underlying grading rules |

**Verification:** `sync.sh --check` / `--check-instructions` / `--check-placeholders` all pass (99 tasks total, including these 43 customized ones); the repo's jest suite (`test/test_tasks.ts`, 23/23) passes, including the "introspection judge assets are in sync with shared/judge" check.

## Testing

1. Offline regrade (3 previously-completed agent runs, re-scored without re-running the agent or any live AWS calls)

All 43 tasks agree with the original judge (43/43) agent comparing the original holistic judge vs. the new per-claim decomposed judge on the same trials.

2. Live end-to-end testing against a real AWS account

All 43 tasks were also run live and end-to-end — real agent, real disposable AWS scenario account, real judge model call — through the actual production grading path, not simulated. The final sweep produced 43/43 tasks with zero unresolved placeholder tokens in any criterion.

## Follow-ups

- Gradual rollout to other partitions. This PR is basic-only; the same approach should roll out to advanced as separate PRs.