### PR TITLE
Fix/quickstart basic criteria names

### DIFF
--- a/tasks/databases-and-storage/analyze-s-intelligent-tiering-configs/tests/judge.toml
+++ b/tasks/databases-and-storage/analyze-s-intelligent-tiering-configs/tests/judge.toml
@@ -8,17 +8,17 @@ prompt_template = "judge_prompt.md"
 mode = "batched"
 
 [[criterion]]
-name = "you_have_two_s3_buckets_without_intelligent_tier"
+name = "two_buckets_lack_intelligent_tiering"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): You have two S3 buckets without Intelligent-Tiering configurations currently in your account"
 type = "binary"
 
 [[criterion]]
-name = "one_s3_bucket_without_intelligent_tiering_config"
+name = "bucket_1_lacks_intelligent_tiering"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): One S3 bucket without Intelligent-Tiering configuration is named {{databases-and-storage-S3-18475e2fc-us-east-1-S3BucketWithoutIntelligentTieringConfigurations1}}"
 type = "binary"
 
 [[criterion]]
-name = "one_s3_bucket_without_intelligent_tiering_config_2"
+name = "bucket_2_lacks_intelligent_tiering"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): One S3 bucket without Intelligent-Tiering configuration is named {{databases-and-storage-S3-18475e2fc-us-east-1-S3BucketWithoutIntelligentTieringConfigurations2}}"
 type = "binary"
 

--- a/tasks/databases-and-storage/check-codebuild-project-nodejs-version/tests/judge.toml
+++ b/tasks/databases-and-storage/check-codebuild-project-nodejs-version/tests/judge.toml
@@ -8,7 +8,7 @@ prompt_template = "judge_prompt.md"
 mode = "batched"
 
 [[criterion]]
-name = "the_node_js_version_configured_for_the_codebuild"
+name = "codebuild_project_node_version"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The Node.js version configured for the CodeBuild project {{databases-and-storage-codebuild-g5etw5eu5-us-east-1-ProjectName}} is {{databases-and-storage-codebuild-g5etw5eu5-us-east-1-NodeVersion}}."
 type = "binary"
 

--- a/tasks/databases-and-storage/check-s-bucket-access-profiles/tests/judge.toml
+++ b/tasks/databases-and-storage/check-s-bucket-access-profiles/tests/judge.toml
@@ -8,42 +8,42 @@ prompt_template = "judge_prompt.md"
 mode = "batched"
 
 [[criterion]]
-name = "the_iam_user_databases_and_storage_s3_8hdgte56j_"
+name = "dev_user_has_read_access"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The IAM user {{databases-and-storage-s3-8hdgte56j-us-east-1-DevProfileUserName}} has read access to the bucket {{databases-and-storage-s3-8hdgte56j-us-east-1-BucketName}}"
 type = "binary"
 
 [[criterion]]
-name = "databases_and_storage_s3_8hdgte56j_us_east_1_dev"
+name = "dev_user_has_getobject_via_bucket_policy"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): {{databases-and-storage-s3-8hdgte56j-us-east-1-DevProfileUserName}} has s3:GetObject permission on {{databases-and-storage-s3-8hdgte56j-us-east-1-BucketName}} via the bucket's resource policy"
 type = "binary"
 
 [[criterion]]
-name = "databases_and_storage_s3_8hdgte56j_us_east_1_dev_2"
+name = "dev_user_has_listbucket_via_bucket_policy"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): {{databases-and-storage-s3-8hdgte56j-us-east-1-DevProfileUserName}} has s3:ListBucket permission on {{databases-and-storage-s3-8hdgte56j-us-east-1-BucketName}} via the bucket's resource policy"
 type = "binary"
 
 [[criterion]]
-name = "the_user_databases_and_storage_s3_8hdgte56j_us_e"
+name = "staging_user_lacks_bucket_access"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The user {{databases-and-storage-s3-8hdgte56j-us-east-1-StagingProfileUserName}} does not have access to {{databases-and-storage-s3-8hdgte56j-us-east-1-BucketName}}"
 type = "binary"
 
 [[criterion]]
-name = "databases_and_storage_s3_8hdgte56j_us_east_1_sta"
+name = "staging_user_has_no_identity_policies"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): {{databases-and-storage-s3-8hdgte56j-us-east-1-StagingProfileUserName}} has no identity-based policies"
 type = "binary"
 
 [[criterion]]
-name = "databases_and_storage_s3_8hdgte56j_us_east_1_sta_2"
+name = "staging_user_not_in_bucket_policy"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): {{databases-and-storage-s3-8hdgte56j-us-east-1-StagingProfileUserName}} is not referenced in the bucket policy of {{databases-and-storage-s3-8hdgte56j-us-east-1-BucketName}}"
 type = "binary"
 
 [[criterion]]
-name = "no_other_iam_users_in_the_account_have_access_to"
+name = "no_other_users_have_bucket_access"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): No other IAM users in the account have access to {{databases-and-storage-s3-8hdgte56j-us-east-1-BucketName}}"
 type = "binary"
 
 [[criterion]]
-name = "the_bucket_databases_and_storage_s3_8hdgte56j_us"
+name = "bucket_contains_expected_content"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The bucket {{databases-and-storage-s3-8hdgte56j-us-east-1-BucketName}} contains {{databases-and-storage-s3-8hdgte56j-us-east-1-Content}}"
 type = "binary"
 

--- a/tasks/databases-and-storage/check-s-vector-bucket-indexes-exist/tests/judge.toml
+++ b/tasks/databases-and-storage/check-s-vector-bucket-indexes-exist/tests/judge.toml
@@ -8,22 +8,22 @@ prompt_template = "judge_prompt.md"
 mode = "batched"
 
 [[criterion]]
-name = "the_first_index_databases_and_storage_s3_jayd5c4"
+name = "first_index_contains_vectors"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The first index {{databases-and-storage-s3-jayd5c428-us-east-1-FirstVectorIndex}} contains vectors"
 type = "binary"
 
 [[criterion]]
-name = "the_first_index_databases_and_storage_s3_jayd5c4_2"
+name = "first_index_has_three_documents"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The first index {{databases-and-storage-s3-jayd5c428-us-east-1-FirstVectorIndex}} contains 3 documents. The instruction only asks to check if vectors exist, not to state a document count or metadata -- credit this claim if the junior's answer confirms vectors exist in this index and does not contradict a count of 3, even if the junior never explicitly states the count."
 type = "binary"
 
 [[criterion]]
-name = "the_second_index_databases_and_storage_s3_jayd5c"
+name = "second_index_is_empty"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The second index {{databases-and-storage-s3-jayd5c428-us-east-1-SecondVectorIndex}} is empty"
 type = "binary"
 
 [[criterion]]
-name = "no_vectors_exist_in_databases_and_storage_s3_jay"
+name = "second_index_lacks_vectors"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): No vectors exist in {{databases-and-storage-s3-jayd5c428-us-east-1-SecondVectorIndex}}"
 type = "binary"
 

--- a/tasks/databases-and-storage/cloudformation-top-stacks-resource-breakdown/tests/judge.toml
+++ b/tasks/databases-and-storage/cloudformation-top-stacks-resource-breakdown/tests/judge.toml
@@ -8,32 +8,32 @@ prompt_template = "judge_prompt.md"
 mode = "batched"
 
 [[criterion]]
-name = "the_stack_with_the_most_resources_is_4dd10da5_st"
+name = "stack_1_has_most_resources"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The stack with the most resources is {{4dd10da5-Stack1Name}} with {{4dd10da5-Stack1Count}} resources"
 type = "binary"
 
 [[criterion]]
-name = "the_top_3_resource_types_in_4dd10da5_stack1name_"
+name = "stack_1_top_three_types"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The top 3 resource types in {{4dd10da5-Stack1Name}} are {{4dd10da5-Stack1TopTypes}}"
 type = "binary"
 
 [[criterion]]
-name = "the_stack_with_the_second_most_resources_is_4dd1"
+name = "stack_2_has_second_most_resources"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The stack with the second most resources is {{4dd10da5-Stack2Name}} with {{4dd10da5-Stack2Count}} resources"
 type = "binary"
 
 [[criterion]]
-name = "the_top_3_resource_types_in_4dd10da5_stack2name_"
+name = "stack_2_top_three_types"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The top 3 resource types in {{4dd10da5-Stack2Name}} are {{4dd10da5-Stack2TopTypes}}"
 type = "binary"
 
 [[criterion]]
-name = "the_stack_with_the_third_most_resources_is_4dd10"
+name = "stack_3_has_third_most_resources"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The stack with the third most resources is {{4dd10da5-Stack3Name}} with {{4dd10da5-Stack3Count}} resources"
 type = "binary"
 
 [[criterion]]
-name = "the_top_3_resource_types_in_4dd10da5_stack3name_"
+name = "stack_3_top_three_types"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The top 3 resource types in {{4dd10da5-Stack3Name}} are {{4dd10da5-Stack3TopTypes}}"
 type = "binary"
 

--- a/tasks/databases-and-storage/compare-s-bucket-structure-sizes/tests/judge.toml
+++ b/tasks/databases-and-storage/compare-s-bucket-structure-sizes/tests/judge.toml
@@ -8,22 +8,22 @@ prompt_template = "judge_prompt.md"
 mode = "batched"
 
 [[criterion]]
-name = "databases_and_storage_s3_3kmc99rnc_us_east_1_buc"
+name = "bucket_1_contains_subdirectory_1"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): {{databases-and-storage-s3-3kmc99rnc-us-east-1-Bucket1Name}} contains folder structure {{databases-and-storage-s3-3kmc99rnc-us-east-1-SubDirectory1Name}}"
 type = "binary"
 
 [[criterion]]
-name = "databases_and_storage_s3_3kmc99rnc_us_east_1_buc_2"
+name = "bucket_2_contains_subdirectory_2"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): {{databases-and-storage-s3-3kmc99rnc-us-east-1-Bucket2Name}} contains folder structure {{databases-and-storage-s3-3kmc99rnc-us-east-1-SubDirectory2Name}}"
 type = "binary"
 
 [[criterion]]
-name = "the_file_content_in_databases_and_storage_s3_3km"
+name = "subdirectory_files_match_name_and_size"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The files in {{databases-and-storage-s3-3kmc99rnc-us-east-1-SubDirectory1Name}} and {{databases-and-storage-s3-3kmc99rnc-us-east-1-SubDirectory2Name}} are consistent with each other (matching name and size). The instruction only asks to compare structure and file sizes, not byte-level content -- do not require the junior to explicitly verify or state that file CONTENT is identical; matching file name and size (already covered by the size claim below) is sufficient evidence to satisfy this claim."
 type = "binary"
 
 [[criterion]]
-name = "the_file_size_in_both_databases_and_storage_s3_3"
+name = "file_size_is_14_bytes"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The file size in both {{databases-and-storage-s3-3kmc99rnc-us-east-1-SubDirectory1Name}} and {{databases-and-storage-s3-3kmc99rnc-us-east-1-SubDirectory2Name}} is 14 bytes"
 type = "binary"
 

--- a/tasks/databases-and-storage/count-cfn-stacks-with-s-buckets/tests/judge.toml
+++ b/tasks/databases-and-storage/count-cfn-stacks-with-s-buckets/tests/judge.toml
@@ -8,22 +8,22 @@ prompt_template = "judge_prompt.md"
 mode = "batched"
 
 [[criterion]]
-name = "in_us_east_1_00da49d8_totalstackswiths3_active_c"
+name = "stacks_declare_s3_bucket"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): In us-east-1, {{00da49d8-TotalStacksWithS3}} active CloudFormation stacks declare an S3 bucket resource"
 type = "binary"
 
 [[criterion]]
-name = "00da49d8_regularbucketstackcount_contain_a_regul"
+name = "stacks_contain_regular_bucket"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): {{00da49d8-RegularBucketStackCount}} contain a regular `AWS::S3::Bucket`"
 type = "binary"
 
 [[criterion]]
-name = "vector_buckets_aws_s3vectors_vectorbucket_are_de"
+name = "vector_bucket_stack_count_matches"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): the number of stacks declaring a vector bucket (`AWS::S3Vectors::VectorBucket`) matches what the reference states (the specific stack(s): {{00da49d8-VectorBucketStacks}}). The instruction's core ask is a count broken down by S3 variant -- do not require the junior to name the specific stack(s); crediting the correct per-variant count alone is sufficient."
 type = "binary"
 
 [[criterion]]
-name = "table_buckets_aws_s3tables_tablebucket_are_decla"
+name = "table_bucket_stack_count_matches"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): the number of stacks declaring a table bucket (`AWS::S3Tables::TableBucket`) matches what the reference states (the specific stack(s): {{00da49d8-TableBucketStacks}}). The instruction's core ask is a count broken down by S3 variant -- do not require the junior to name the specific stack(s); crediting the correct per-variant count alone is sufficient."
 type = "binary"
 

--- a/tasks/databases-and-storage/count-old-s-buckets/tests/judge.toml
+++ b/tasks/databases-and-storage/count-old-s-buckets/tests/judge.toml
@@ -8,7 +8,7 @@ prompt_template = "judge_prompt.md"
 mode = "batched"
 
 [[criterion]]
-name = "you_have_c480b808_bucketcount_s3_buckets_that_we"
+name = "s3_buckets_older_than_one_day"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): You have {{c480b808-BucketCount}} S3 buckets that were created more than a day ago."
 type = "binary"
 

--- a/tasks/databases-and-storage/count-sns-topic-sqs-subscribers/tests/judge.toml
+++ b/tasks/databases-and-storage/count-sns-topic-sqs-subscribers/tests/judge.toml
@@ -8,7 +8,7 @@ prompt_template = "judge_prompt.md"
 mode = "batched"
 
 [[criterion]]
-name = "the_total_number_of_subscribers_subscribed_to_al"
+name = "total_sns_subscribers_us_west_2"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The total number of subscribers subscribed to all SNS topics in us-west-2 is {{databases-and-storage-SQS-e5ldy6q5p-us-west-2-NUMSubscribers}}."
 type = "binary"
 

--- a/tasks/databases-and-storage/count-windows-server-managed-nodes/tests/judge.toml
+++ b/tasks/databases-and-storage/count-windows-server-managed-nodes/tests/judge.toml
@@ -8,7 +8,7 @@ prompt_template = "judge_prompt.md"
 mode = "batched"
 
 [[criterion]]
-name = "you_have_databases_and_storage_ssm_a1b2c3d46_us_"
+name = "windows_2022_managed_node_count"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): You have {{databases-and-storage-SSM-a1b2c3d46-us-east-1-NumberOfWindows2022ManagedNodes}} Windows Server 2022 managed node in us-east-1."
 type = "binary"
 

--- a/tasks/databases-and-storage/dynamodb-query-workflow-status-analysis/tests/judge.toml
+++ b/tasks/databases-and-storage/dynamodb-query-workflow-status-analysis/tests/judge.toml
@@ -8,42 +8,42 @@ prompt_template = "judge_prompt.md"
 mode = "batched"
 
 [[criterion]]
-name = "record_with_id_web_003_has_workflowid_wf_alpha_a"
+name = "web_003_has_wf_alpha_completed"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): Record with id=web-003 has workflowId=wf-alpha and status=completed"
 type = "binary"
 
 [[criterion]]
-name = "record_with_id_web_001_has_workflowid_wf_alpha_a"
+name = "web_001_has_wf_alpha_completed"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): Record with id=web-001 has workflowId=wf-alpha and status=completed"
 type = "binary"
 
 [[criterion]]
-name = "record_with_id_web_002_has_workflowid_wf_beta_an"
+name = "web_002_has_wf_beta_processing"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): Record with id=web-002 has workflowId=wf-beta and status=processing"
 type = "binary"
 
 [[criterion]]
-name = "2_records_have_status_completed"
+name = "two_records_completed_status"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): 2 records have status \"completed\""
 type = "binary"
 
 [[criterion]]
-name = "3_total_records_scanned"
+name = "three_total_records_scanned"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): 3 total records scanned. The instruction only asks for sample records, the completed-status count, and the unique workflow ID list -- it does not ask for an explicit total-scanned count. Credit this claim if the junior's shown records/answer are consistent with a total of 3 and do not contradict it, even if the junior never explicitly states the total."
 type = "binary"
 
 [[criterion]]
-name = "wf_alpha_appears_2_times"
+name = "wf_alpha_appears_twice"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): wf-alpha appears 2 times. The instruction only asks for the list of unique workflow IDs, not their frequency counts -- credit this claim if the junior's shown sample records are consistent with wf-alpha appearing 2 times and do not contradict it, even if the junior never explicitly restates the count."
 type = "binary"
 
 [[criterion]]
-name = "wf_beta_appears_1_time"
+name = "wf_beta_appears_once"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): wf-beta appears 1 time. The instruction only asks for the list of unique workflow IDs, not their frequency counts -- credit this claim if the junior's shown sample records are consistent with wf-beta appearing 1 time and do not contradict it, even if the junior never explicitly restates the count."
 type = "binary"
 
 [[criterion]]
-name = "the_table_contains_2_unique_workflow_ids"
+name = "two_unique_workflow_ids"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The table contains 2 unique workflow IDs"
 type = "binary"
 

--- a/tasks/databases-and-storage/dynamodb-scan-and-fetch-record/tests/judge.toml
+++ b/tasks/databases-and-storage/dynamodb-scan-and-fetch-record/tests/judge.toml
@@ -8,32 +8,32 @@ prompt_template = "judge_prompt.md"
 mode = "batched"
 
 [[criterion]]
-name = "the_scan_of_dynamodb_table_databases_and_storage"
+name = "table_scan_returned_20_items"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The scan of DynamoDB table {{databases-and-storage-dynamodb-ghjk456ad-us-east-1-TableName}} returned 20 items"
 type = "binary"
 
 [[criterion]]
-name = "the_record_with_contentid_databases_and_storage_"
+name = "record_has_task_id_task012"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The record with ContentId {{databases-and-storage-dynamodb-ghjk456ad-us-east-1-ContentId}} has TaskId TASK012"
 type = "binary"
 
 [[criterion]]
-name = "the_record_with_contentid_databases_and_storage__2"
+name = "record_has_database_backup_description"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The record with ContentId {{databases-and-storage-dynamodb-ghjk456ad-us-east-1-ContentId}} has Description 'Database backup'"
 type = "binary"
 
 [[criterion]]
-name = "the_record_with_contentid_databases_and_storage__3"
+name = "record_has_low_priority"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The record with ContentId {{databases-and-storage-dynamodb-ghjk456ad-us-east-1-ContentId}} has Priority LOW"
 type = "binary"
 
 [[criterion]]
-name = "the_record_with_contentid_databases_and_storage__4"
+name = "record_has_blocked_status"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The record with ContentId {{databases-and-storage-dynamodb-ghjk456ad-us-east-1-ContentId}} has TaskStatus BLOCKED"
 type = "binary"
 
 [[criterion]]
-name = "the_record_with_contentid_databases_and_storage__5"
+name = "record_assigned_to_user4"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The record with ContentId {{databases-and-storage-dynamodb-ghjk456ad-us-east-1-ContentId}} is assigned to user4@example.com"
 type = "binary"
 

--- a/tasks/databases-and-storage/dynamodb-scan-filter-by-attribute/tests/judge.toml
+++ b/tasks/databases-and-storage/dynamodb-scan-filter-by-attribute/tests/judge.toml
@@ -8,27 +8,27 @@ prompt_template = "judge_prompt.md"
 mode = "batched"
 
 [[criterion]]
-name = "the_dynamodb_table_databases_and_storage_dynamod"
+name = "dynamodb_scan_completed_successfully"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The DynamoDB table {{databases-and-storage-dynamodb-gsdf23tr4-us-east-1-TableName}} scan has been completed successfully"
 type = "binary"
 
 [[criterion]]
-name = "the_scan_retrieved_all_items_containing_the_spec"
+name = "scan_retrieved_specified_attributes"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The scan retrieved all items containing the specified attributes {{databases-and-storage-dynamodb-gsdf23tr4-us-east-1-AttributeNames}}"
 type = "binary"
 
 [[criterion]]
-name = "found_3_items_total_in_the_table"
+name = "found_three_items_total"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): Found 3 items total in the table"
 type = "binary"
 
 [[criterion]]
-name = "1_item_with_status_inactive"
+name = "one_item_status_inactive"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): 1 item with status \"inactive\""
 type = "binary"
 
 [[criterion]]
-name = "2_items_with_status_active"
+name = "two_items_status_active"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): 2 items with status \"active\""
 type = "binary"
 

--- a/tasks/databases-and-storage/dynamodb-tables-resource-based-policy/tests/judge.toml
+++ b/tasks/databases-and-storage/dynamodb-tables-resource-based-policy/tests/judge.toml
@@ -8,12 +8,12 @@ prompt_template = "judge_prompt.md"
 mode = "batched"
 
 [[criterion]]
-name = "the_dynamodb_table_named_databases_and_storage_d"
+name = "us_east_1_table_has_resource_policy"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The DynamoDB table named {{databases-and-storage-DynamoDB-a9d78fhs7-us-east-1-DynamoDBTableTableWithPolicy}} in the us-east-1 region has a resource-based policy"
 type = "binary"
 
 [[criterion]]
-name = "the_dynamodb_table_named_databases_and_storage_d_2"
+name = "us_west_2_table_has_resource_policy"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The DynamoDB table named {{databases-and-storage-DynamoDB-a9d78fhs7-us-west-2-DynamoDBTableTableWithPolicy}} in the us-west-2 region has a resource-based policy"
 type = "binary"
 

--- a/tasks/databases-and-storage/estimate-ec-running-instance-costs/tests/judge.toml
+++ b/tasks/databases-and-storage/estimate-ec-running-instance-costs/tests/judge.toml
@@ -8,12 +8,12 @@ prompt_template = "judge_prompt.md"
 mode = "batched"
 
 [[criterion]]
-name = "the_total_estimated_hourly_on_demand_cost_is_f62"
+name = "total_hourly_cost_matches"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The total estimated hourly on-demand cost is {{f6287f43-TotalHourlyCost}}"
 type = "binary"
 
 [[criterion]]
-name = "the_breakdown_by_instance_type_and_operating_sys"
+name = "breakdown_by_type_and_os_matches"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The breakdown by instance type and operating system is {{f6287f43-Breakdown}}"
 type = "binary"
 

--- a/tasks/databases-and-storage/get-s-bucket-ownership-controls/tests/judge.toml
+++ b/tasks/databases-and-storage/get-s-bucket-ownership-controls/tests/judge.toml
@@ -8,17 +8,17 @@ prompt_template = "judge_prompt.md"
 mode = "batched"
 
 [[criterion]]
-name = "the_object_ownership_for_databases_and_storage_s"
+name = "bucket_1_object_ownership_status"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The object ownership for {{databases-and-storage-S3-18475e2fc-us-east-1-EmptyS3Bucket1}} is {{databases-and-storage-S3-18475e2fc-us-east-1-ACLStatus1}}"
 type = "binary"
 
 [[criterion]]
-name = "the_object_ownership_for_databases_and_storage_s_2"
+name = "bucket_2_object_ownership_status"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The object ownership for {{databases-and-storage-S3-18475e2fc-us-east-1-EmptyS3Bucket2}} is {{databases-and-storage-S3-18475e2fc-us-east-1-ACLStatus1}}"
 type = "binary"
 
 [[criterion]]
-name = "the_object_ownership_for_databases_and_storage_s_3"
+name = "lifecycle_bucket_object_ownership_status"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The object ownership for {{databases-and-storage-S3-18475e2fc-us-east-1-S3BucketWithLifeCycleRules}} is {{databases-and-storage-S3-18475e2fc-us-east-1-ACLStatus3}}"
 type = "binary"
 

--- a/tasks/databases-and-storage/glue-database-tables-schema-details/tests/judge.toml
+++ b/tasks/databases-and-storage/glue-database-tables-schema-details/tests/judge.toml
@@ -8,22 +8,22 @@ prompt_template = "judge_prompt.md"
 mode = "batched"
 
 [[criterion]]
-name = "the_database_databases_and_storage_athena_ton59i"
+name = "database_contains_one_table"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The database {{databases-and-storage-athena-ton59ib3f-us-east-1-DatabaseName}} contains one table: andes_3_0_data"
 type = "binary"
 
 [[criterion]]
-name = "the_table_andes_3_0_data_has_3_columns_id_bigint"
+name = "table_has_three_columns"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The table andes_3_0_data has 3 columns: id (bigint), name (string), and created_date (date)"
 type = "binary"
 
 [[criterion]]
-name = "the_table_andes_3_0_data_is_an_external_table"
+name = "table_is_external_type"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The table andes_3_0_data is an EXTERNAL_TABLE (i.e. its data is stored externally in S3 rather than managed internally by Glue). The junior does not need to use the literal term 'EXTERNAL_TABLE' -- stating that the table's data or location is in S3 is equivalent evidence and is sufficient to satisfy this claim."
 type = "binary"
 
 [[criterion]]
-name = "the_table_andes_3_0_data_has_data_stored_in_s3"
+name = "table_data_stored_in_s3"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The table andes_3_0_data has data stored in S3"
 type = "binary"
 

--- a/tasks/databases-and-storage/investigate-athena-table-creation-origin/tests/judge.toml
+++ b/tasks/databases-and-storage/investigate-athena-table-creation-origin/tests/judge.toml
@@ -8,37 +8,37 @@ prompt_template = "judge_prompt.md"
 mode = "batched"
 
 [[criterion]]
-name = "the_athena_table_databases_and_storage_athena_9j"
+name = "athena_table_created_by_cloudformation"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The Athena table {{databases-and-storage-athena-9jhgt3tfs-us-east-1-TableName}} was created using the CloudFormation stack named {{databases-and-storage-athena-9jhgt3tfs-us-east-1-StackName}}"
 type = "binary"
 
 [[criterion]]
-name = "the_resource_was_created_as_an_aws_glue_table_re"
+name = "resource_type_is_glue_table"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The resource was created as an AWS::Glue::Table resource in CloudFormation"
 type = "binary"
 
 [[criterion]]
-name = "it_has_a_storagedescriptor_pointing_to_actual_da"
+name = "storage_descriptor_points_to_s3"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): It has a StorageDescriptor pointing to actual data in S3"
 type = "binary"
 
 [[criterion]]
-name = "it_has_no_vieworiginaltext_property"
+name = "no_view_original_text_property"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): It has no ViewOriginalText property"
 type = "binary"
 
 [[criterion]]
-name = "it_has_no_viewexpandedtext_property"
+name = "no_view_expanded_text_property"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): It has no ViewExpandedText property"
 type = "binary"
 
 [[criterion]]
-name = "ismultidialectview_is_false"
+name = "is_multi_dialect_view_false"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): IsMultiDialectView is false"
 type = "binary"
 
 [[criterion]]
-name = "the_resource_shows_as_a_table_rather_than_a_view"
+name = "displays_as_table_not_view"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The resource shows as a table rather than a view because it was created as an AWS::Glue::Table resource in CloudFormation, has a StorageDescriptor pointing to actual data in S3, and has no view-related properties (ViewOriginalText, ViewExpandedText) or view flags (IsMultiDialectView is false)"
 type = "binary"
 

--- a/tasks/databases-and-storage/list-buckets-with-lifecycle-policy/tests/judge.toml
+++ b/tasks/databases-and-storage/list-buckets-with-lifecycle-policy/tests/judge.toml
@@ -8,7 +8,7 @@ prompt_template = "judge_prompt.md"
 mode = "batched"
 
 [[criterion]]
-name = "you_have_one_s3_bucket_with_lifecycle_policy_set"
+name = "bucket_has_lifecycle_policy"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): You have one S3 bucket with lifecycle policy set named {{databases-and-storage-S3-18475e2fc-us-east-1-S3BucketWithLifeCycleRules}}."
 type = "binary"
 

--- a/tasks/databases-and-storage/list-dynamodb-kinesis-streams-all-regions/tests/judge.toml
+++ b/tasks/databases-and-storage/list-dynamodb-kinesis-streams-all-regions/tests/judge.toml
@@ -8,12 +8,12 @@ prompt_template = "judge_prompt.md"
 mode = "batched"
 
 [[criterion]]
-name = "the_dynamodb_table_named_databases_and_storage_d"
+name = "dynamodb_table_has_kinesis_streams"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The DynamoDB table named {{databases-and-storage-DynamoDB-a9d78fhs7-us-east-1-DynamoDBTableWithStream}} in the us-east-1 region has Kinesis streams configured"
 type = "binary"
 
 [[criterion]]
-name = "the_dynamodb_table_named_databases_and_storage_d_2"
+name = "dynamodb_table_has_kinesis_streams_2"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The DynamoDB table named {{databases-and-storage-DynamoDB-a9d78fhs7-us-west-2-DynamoDBTableWithStream}} in the us-west-2 region has Kinesis streams configured"
 type = "binary"
 

--- a/tasks/databases-and-storage/list-dynamodb-tables-all-regions/tests/judge.toml
+++ b/tasks/databases-and-storage/list-dynamodb-tables-all-regions/tests/judge.toml
@@ -8,82 +8,82 @@ prompt_template = "judge_prompt.md"
 mode = "batched"
 
 [[criterion]]
-name = "there_are_12_tables_currently_active_in_dynamodb"
+name = "us_east_1_has_12_tables"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): There are 12 tables currently active in DynamoDB in the us-east-1 region"
 type = "binary"
 
 [[criterion]]
-name = "the_us_east_1_dynamodb_tables_include_databases_"
+name = "us_east_1_includes_dynamodbtablename"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The us-east-1 DynamoDB tables include {{databases-and-storage-dynamodb-ge54tw65t-us-east-1-DynamoDBTableName}}"
 type = "binary"
 
 [[criterion]]
-name = "the_us_east_1_dynamodb_tables_include_databases__2"
+name = "us_east_1_includes_tablename_1"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The us-east-1 DynamoDB tables include {{databases-and-storage-dynamodb-tk2o3jasd-us-east-1-TableName}}"
 type = "binary"
 
 [[criterion]]
-name = "the_us_east_1_dynamodb_tables_include_databases__3"
+name = "us_east_1_includes_tablename_2"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The us-east-1 DynamoDB tables include {{databases-and-storage-dynamodb-ghjk456ad-us-east-1-TableName}}"
 type = "binary"
 
 [[criterion]]
-name = "the_us_east_1_dynamodb_tables_include_databases__4"
+name = "us_east_1_includes_inventorytablename"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The us-east-1 DynamoDB tables include {{databases-and-storage-dynamodb-adhk146bg-us-east-1-InventoryTableName}}"
 type = "binary"
 
 [[criterion]]
-name = "the_us_east_1_dynamodb_tables_include_databases__5"
+name = "us_east_1_includes_orderstablename"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The us-east-1 DynamoDB tables include {{databases-and-storage-dynamodb-adhk146bg-us-east-1-OrdersTableName}}"
 type = "binary"
 
 [[criterion]]
-name = "the_us_east_1_dynamodb_tables_include_databases__6"
+name = "us_east_1_includes_tablename_3"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The us-east-1 DynamoDB tables include {{databases-and-storage-dynamodb-gsdf23tr4-us-east-1-TableName}}"
 type = "binary"
 
 [[criterion]]
-name = "the_us_east_1_dynamodb_tables_include_databases__7"
+name = "us_east_1_includes_tablename_4"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The us-east-1 DynamoDB tables include {{databases-and-storage-dynamodb-kdf231sdf-us-east-1-TableName}}"
 type = "binary"
 
 [[criterion]]
-name = "the_us_east_1_dynamodb_tables_include_databases__8"
+name = "us_east_1_includes_productstablename"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The us-east-1 DynamoDB tables include {{databases-and-storage-dynamodb-adhk146bg-us-east-1-ProductsTableName}}"
 type = "binary"
 
 [[criterion]]
-name = "the_us_east_1_dynamodb_tables_include_databases__9"
+name = "us_east_1_includes_cfn_dynamodbtablename"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The us-east-1 DynamoDB tables include {{databases-and-storage-CFN-ax9w8fhs7-us-east-1-DynamoDBTableName}}"
 type = "binary"
 
 [[criterion]]
-name = "the_us_east_1_dynamodb_tables_include_databases__10"
+name = "us_east_1_includes_tablewithstream"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The us-east-1 DynamoDB tables include {{databases-and-storage-DynamoDB-a9d78fhs7-us-east-1-DynamoDBTableWithStream}}"
 type = "binary"
 
 [[criterion]]
-name = "the_us_east_1_dynamodb_tables_include_databases__11"
+name = "us_east_1_includes_tablewithpolicy"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The us-east-1 DynamoDB tables include {{databases-and-storage-DynamoDB-a9d78fhs7-us-east-1-DynamoDBTableTableWithPolicy}}"
 type = "binary"
 
 [[criterion]]
-name = "the_us_east_1_dynamodb_tables_include_databases__12"
+name = "us_east_1_includes_userstablename"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The us-east-1 DynamoDB tables include {{databases-and-storage-dynamodb-adhk146bg-us-east-1-UsersTableName}}"
 type = "binary"
 
 [[criterion]]
-name = "there_are_2_tables_in_us_west_2"
+name = "us_west_2_has_2_tables"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): There are 2 tables in us-west-2"
 type = "binary"
 
 [[criterion]]
-name = "the_us_west_2_dynamodb_tables_include_databases_"
+name = "us_west_2_includes_tablewithstream"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The us-west-2 DynamoDB tables include {{databases-and-storage-DynamoDB-a9d78fhs7-us-west-2-DynamoDBTableWithStream}}"
 type = "binary"
 
 [[criterion]]
-name = "the_us_west_2_dynamodb_tables_include_databases__2"
+name = "us_west_2_includes_tablewithpolicy"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The us-west-2 DynamoDB tables include {{databases-and-storage-DynamoDB-a9d78fhs7-us-west-2-DynamoDBTableTableWithPolicy}}"
 type = "binary"
 

--- a/tasks/databases-and-storage/list-s-bucket-subdirectories/tests/judge.toml
+++ b/tasks/databases-and-storage/list-s-bucket-subdirectories/tests/judge.toml
@@ -8,12 +8,12 @@ prompt_template = "judge_prompt.md"
 mode = "batched"
 
 [[criterion]]
-name = "databases_and_storage_s3_eor38cdr9_us_east_1_sub"
+name = "subdirectory_exists_in_bucket"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): {{databases-and-storage-s3-eor38cdr9-us-east-1-SubDirectoryName}} is an immediate subdirectory in the S3 bucket {{databases-and-storage-s3-eor38cdr9-us-east-1-BucketName}}"
 type = "binary"
 
 [[criterion]]
-name = "databases_and_storage_s3_eor38cdr9_us_east_1_sub_2"
+name = "subdirectory_is_only_immediate_child"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): {{databases-and-storage-s3-eor38cdr9-us-east-1-SubDirectoryName}} is the only immediate subdirectory in the S3 bucket {{databases-and-storage-s3-eor38cdr9-us-east-1-BucketName}}"
 type = "binary"
 

--- a/tasks/databases-and-storage/list-waf-webacl-findings/tests/judge.toml
+++ b/tasks/databases-and-storage/list-waf-webacl-findings/tests/judge.toml
@@ -8,32 +8,32 @@ prompt_template = "judge_prompt.md"
 mode = "batched"
 
 [[criterion]]
-name = "the_webacl_has_a_default_action_set_to_databases"
+name = "webacl_default_action_identified"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The WebACL has a default action set to {{databases-and-storage-WAF-18b01a02d-us-east-1-WebAcldefaultAction}}"
 type = "binary"
 
 [[criterion]]
-name = "the_webacl_has_a_rate_limiting_rule_named_databa"
+name = "rate_limiting_rule_name_identified"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The WebACL has a rate-limiting rule named {{databases-and-storage-WAF-18b01a02d-us-east-1-RuleName}}"
 type = "binary"
 
 [[criterion]]
-name = "the_rate_limiting_rule_has_a_priority_of_databas"
+name = "rate_limiting_rule_priority_identified"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The rate-limiting rule has a priority of {{databases-and-storage-WAF-18b01a02d-us-east-1-RulePriority}}"
 type = "binary"
 
 [[criterion]]
-name = "the_rate_limiting_rule_blocks_ip_addresses_excee"
+name = "rate_limit_threshold_identified"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The rate-limiting rule blocks IP addresses exceeding {{databases-and-storage-WAF-18b01a02d-us-east-1-RuleRateLimit}} requests"
 type = "binary"
 
 [[criterion]]
-name = "the_web_acl_id_is_databases_and_storage_waf_18b0"
+name = "webacl_id_identified"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The Web ACL ID is {{databases-and-storage-WAF-18b01a02d-us-east-1-WebAclId}}"
 type = "binary"
 
 [[criterion]]
-name = "the_web_acl_arn_is_databases_and_storage_waf_18b"
+name = "webacl_arn_components_identified"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The Web ACL ARN is {{databases-and-storage-WAF-18b01a02d-us-east-1-WebAclArn}}. The instruction only asks to describe rule configuration, not to state the ARN as one assembled string -- credit this claim if the junior's answer contains all the components needed to construct the ARN (account, region, WebACL name/ID), even if never assembled into one literal ARN string."
 type = "binary"
 

--- a/tasks/databases-and-storage/query-dynamodb-filtered-records-count/tests/judge.toml
+++ b/tasks/databases-and-storage/query-dynamodb-filtered-records-count/tests/judge.toml
@@ -8,7 +8,7 @@ prompt_template = "judge_prompt.md"
 mode = "batched"
 
 [[criterion]]
-name = "there_are_databases_and_storage_dynamodb_tk2o3ja"
+name = "records_have_empty_tag_and_nonzero_resolvedat"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): There are {{databases-and-storage-dynamodb-tk2o3jasd-us-east-1-RecordCount}} records with an empty tag field and a ResolvedAt value greater than zero in the DynamoDB table {{databases-and-storage-dynamodb-tk2o3jasd-us-east-1-TableName}}"
 type = "binary"
 

--- a/tasks/databases-and-storage/report-unencrypted-s-buckets/tests/judge.toml
+++ b/tasks/databases-and-storage/report-unencrypted-s-buckets/tests/judge.toml
@@ -8,17 +8,17 @@ prompt_template = "judge_prompt.md"
 mode = "batched"
 
 [[criterion]]
-name = "the_bucket_prod_bucket_jdn294ng4_uses_aws_kms_en"
+name = "prod_bucket_uses_kms_encryption"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The bucket prod-bucket-jdn294ng4 uses AWS KMS encryption (SSE-KMS with the AWS-managed key)"
 type = "binary"
 
 [[criterion]]
-name = "the_cdk_infrastructure_staging_buckets_use_kms_e"
+name = "cdk_staging_buckets_use_kms"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The CDK infrastructure staging buckets use KMS encryption"
 type = "binary"
 
 [[criterion]]
-name = "all_other_buckets_use_the_default_s3_managed_enc"
+name = "remaining_buckets_use_default_encryption"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): All other buckets use the default S3-managed encryption (SSE-S3/AES256). If the junior exhaustively and correctly lists which buckets use KMS encryption (matching the other claims above) without claiming that any additional bucket uses a non-default encryption scheme, that satisfies this claim by implication -- the junior does not need to explicitly restate that the remaining buckets use default encryption."
 type = "binary"
 

--- a/tasks/databases-and-storage/retrieve-s-csv-object-contents/tests/judge.toml
+++ b/tasks/databases-and-storage/retrieve-s-csv-object-contents/tests/judge.toml
@@ -8,12 +8,12 @@ prompt_template = "judge_prompt.md"
 mode = "batched"
 
 [[criterion]]
-name = "the_csv_object_file_databases_and_storage_s3_jkd"
+name = "csv_object_exists_in_bucket"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The CSV object file {{databases-and-storage-s3-jkdf342er-us-east-1-ObjectName}} exists in S3 bucket {{databases-and-storage-s3-jkdf342er-us-east-1-BucketName}}"
 type = "binary"
 
 [[criterion]]
-name = "the_contents_of_databases_and_storage_s3_jkdf342"
+name = "csv_object_contains_expected_data"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The contents of {{databases-and-storage-s3-jkdf342er-us-east-1-ObjectName}} are: Name,Age,City\\nJohn,25,New York\\nJane,30,London\\nBob,35,Paris"
 type = "binary"
 

--- a/tasks/databases-and-storage/retrieve-s-text-file-contents/tests/judge.toml
+++ b/tasks/databases-and-storage/retrieve-s-text-file-contents/tests/judge.toml
@@ -8,12 +8,12 @@ prompt_template = "judge_prompt.md"
 mode = "batched"
 
 [[criterion]]
-name = "the_most_similar_file_among_all_s3_buckets_is_sa"
+name = "most_similar_file_is_samplefile_txt"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The most similar file among all S3 buckets is 'samplefile.txt'"
 type = "binary"
 
 [[criterion]]
-name = "the_content_of_samplefile_txt_is_hello_this_is_a"
+name = "samplefile_txt_content_matches"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The content of 'samplefile.txt' is 'Hello, this is a sample text file!'"
 type = "binary"
 

--- a/tasks/databases-and-storage/s-download-csv-identify-columns/tests/judge.toml
+++ b/tasks/databases-and-storage/s-download-csv-identify-columns/tests/judge.toml
@@ -8,17 +8,17 @@ prompt_template = "judge_prompt.md"
 mode = "batched"
 
 [[criterion]]
-name = "the_csv_file_has_6_columns_product_id_name_categ"
+name = "csv_has_six_columns"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The CSV file has 6 columns: product_id, name, category, price, stock, and description."
 type = "binary"
 
 [[criterion]]
-name = "columns_with_all_unique_values_product_id_name_p"
+name = "five_columns_have_unique_values"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): Columns with all unique values: product_id, name, price, stock, and description."
 type = "binary"
 
 [[criterion]]
-name = "column_with_duplicate_values_category_e_g_electr"
+name = "category_column_has_duplicates"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): Column with duplicate values: category (e.g., 'Electronics' appears more than once)."
 type = "binary"
 

--- a/tasks/databases-and-storage/s-object-versions-and-metadata/tests/judge.toml
+++ b/tasks/databases-and-storage/s-object-versions-and-metadata/tests/judge.toml
@@ -8,22 +8,22 @@ prompt_template = "judge_prompt.md"
 mode = "batched"
 
 [[criterion]]
-name = "the_most_recently_modified_object_is_898c7f19_mo"
+name = "most_recent_object_key"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The most recently modified object is `{{898c7f19-MostRecentKey}}`"
 type = "binary"
 
 [[criterion]]
-name = "the_most_recently_modified_object_has_version_id"
+name = "most_recent_object_version_id"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The most recently modified object has version ID `{{898c7f19-MostRecentVersionId}}`"
 type = "binary"
 
 [[criterion]]
-name = "the_object_prod_data_txt_has_version_id_898c7f19"
+name = "prod_data_version_id"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The object `prod_data.txt` has version ID `{{898c7f19-ProdDataVersionId}}`"
 type = "binary"
 
 [[criterion]]
-name = "the_object_prod_data_txt_is_898c7f19_proddatasiz"
+name = "prod_data_size_bytes"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The object `prod_data.txt` is {{898c7f19-ProdDataSizeBytes}} bytes"
 type = "binary"
 

--- a/tasks/databases-and-storage/scan-dynamodb-table-by-status/tests/judge.toml
+++ b/tasks/databases-and-storage/scan-dynamodb-table-by-status/tests/judge.toml
@@ -8,12 +8,12 @@ prompt_template = "judge_prompt.md"
 mode = "batched"
 
 [[criterion]]
-name = "the_dynamodb_table_databases_and_storage_dynamod"
+name = "dynamodb_table_retrieved_five_records"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The DynamoDB table {{databases-and-storage-dynamodb-kdf231sdf-us-east-1-TableName}} retrieved 5 records"
 type = "binary"
 
 [[criterion]]
-name = "the_retrieved_records_have_statuses_including_ac"
+name = "retrieved_records_include_four_statuses"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The retrieved records have statuses including active, inactive, pending, and suspended users"
 type = "binary"
 

--- a/tasks/ec2-multiregion/describe-cloudformation-stack-resources/tests/judge.toml
+++ b/tasks/ec2-multiregion/describe-cloudformation-stack-resources/tests/judge.toml
@@ -38,7 +38,7 @@ description = "Per the rubric, does the junior engineer's answer support this cl
 type = "binary"
 
 [[criterion]]
-name = "stack_contains_default_sg_lockdown_custom_resource"
+name = "stack_contains_default_sg_lockdown_resource"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The stack {{ec2-multiregion-EC2-ls9fuhb522-us-west-1-StackId}} contains a Lambda-backed custom resource that locks down the default security group."
 type = "binary"
 

--- a/tasks/ec2-multiregion/describe-cloudformation-stack-resources/tests/judge.toml
+++ b/tasks/ec2-multiregion/describe-cloudformation-stack-resources/tests/judge.toml
@@ -8,47 +8,47 @@ prompt_template = "judge_prompt.md"
 mode = "batched"
 
 [[criterion]]
-name = "the_stack_ec2_multiregion_ec2_ls9fuhb522_us_west"
+name = "stack_is_cdk_stack"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The stack {{ec2-multiregion-EC2-ls9fuhb522-us-west-1-StackId}} in us-west-1 is a CDK stack."
 type = "binary"
 
 [[criterion]]
-name = "the_stack_ec2_multiregion_ec2_ls9fuhb522_us_west_2"
+name = "stack_contains_vpc"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The stack {{ec2-multiregion-EC2-ls9fuhb522-us-west-1-StackId}} contains a VPC."
 type = "binary"
 
 [[criterion]]
-name = "the_stack_ec2_multiregion_ec2_ls9fuhb522_us_west_3"
+name = "stack_contains_public_subnet"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The stack {{ec2-multiregion-EC2-ls9fuhb522-us-west-1-StackId}} contains a public subnet."
 type = "binary"
 
 [[criterion]]
-name = "the_stack_ec2_multiregion_ec2_ls9fuhb522_us_west_4"
+name = "stack_contains_ec2_instance"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The stack {{ec2-multiregion-EC2-ls9fuhb522-us-west-1-StackId}} contains an EC2 instance {{ec2-multiregion-EC2-ls9fuhb522-us-west-1-InstanceId}}."
 type = "binary"
 
 [[criterion]]
-name = "the_stack_ec2_multiregion_ec2_ls9fuhb522_us_west_5"
+name = "stack_contains_instance_security_group"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The stack {{ec2-multiregion-EC2-ls9fuhb522-us-west-1-StackId}} contains a security group for the EC2 instance."
 type = "binary"
 
 [[criterion]]
-name = "the_stack_ec2_multiregion_ec2_ls9fuhb522_us_west_6"
+name = "stack_contains_iam_role"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The stack {{ec2-multiregion-EC2-ls9fuhb522-us-west-1-StackId}} contains an IAM role."
 type = "binary"
 
 [[criterion]]
-name = "the_stack_ec2_multiregion_ec2_ls9fuhb522_us_west_7"
+name = "stack_contains_default_sg_lockdown_custom_resource"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The stack {{ec2-multiregion-EC2-ls9fuhb522-us-west-1-StackId}} contains a Lambda-backed custom resource that locks down the default security group."
 type = "binary"
 
 [[criterion]]
-name = "the_stack_ec2_multiregion_ec2_ls9fuhb522_us_west_8"
+name = "stack_has_sixteen_resources"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The stack {{ec2-multiregion-EC2-ls9fuhb522-us-west-1-StackId}} has 16 resources in total."
 type = "binary"
 
 [[criterion]]
-name = "all_resources_in_the_stack_ec2_multiregion_ec2_l"
+name = "all_stack_resources_created_successfully"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): All resources in the stack {{ec2-multiregion-EC2-ls9fuhb522-us-west-1-StackId}} were created successfully."
 type = "binary"
 

--- a/tasks/ec2-multiregion/describe-ec-instances-cross-region-connectivity/tests/judge.toml
+++ b/tasks/ec2-multiregion/describe-ec-instances-cross-region-connectivity/tests/judge.toml
@@ -8,17 +8,17 @@ prompt_template = "judge_prompt.md"
 mode = "batched"
 
 [[criterion]]
-name = "us_east_1_instance_count"
+name = "instance_count_in_us_east_1"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): There are {{ec2-multiregion-EC2-ks84v1fh12-us-east-1-NUMEC2Running}} EC2 instances in us-east-1"
 type = "binary"
 
 [[criterion]]
-name = "us_west_1_instance_count"
+name = "instance_count_in_us_west_1"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): There are {{ec2-multiregion-EC2-ls9fuhb522-us-west-1-NUMEC2Running}} EC2 instances in us-west-1"
 type = "binary"
 
 [[criterion]]
-name = "us_west_2_instance_count"
+name = "instance_count_in_us_west_2"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): There are {{ec2-multiregion-EC2-ls9fuhb522-us-west-2-NUMEC2Running}} EC2 instances in us-west-2"
 type = "binary"
 

--- a/tasks/ec2-multiregion/describe-ec-instances-cross-region-connectivity/tests/judge.toml
+++ b/tasks/ec2-multiregion/describe-ec-instances-cross-region-connectivity/tests/judge.toml
@@ -8,27 +8,27 @@ prompt_template = "judge_prompt.md"
 mode = "batched"
 
 [[criterion]]
-name = "there_are_ec2_multiregion_ec2_ks84v1fh12_us_east"
+name = "us_east_1_instance_count"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): There are {{ec2-multiregion-EC2-ks84v1fh12-us-east-1-NUMEC2Running}} EC2 instances in us-east-1"
 type = "binary"
 
 [[criterion]]
-name = "there_are_ec2_multiregion_ec2_ls9fuhb522_us_west"
+name = "us_west_1_instance_count"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): There are {{ec2-multiregion-EC2-ls9fuhb522-us-west-1-NUMEC2Running}} EC2 instances in us-west-1"
 type = "binary"
 
 [[criterion]]
-name = "there_are_ec2_multiregion_ec2_ls9fuhb522_us_west_2"
+name = "us_west_2_instance_count"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): There are {{ec2-multiregion-EC2-ls9fuhb522-us-west-2-NUMEC2Running}} EC2 instances in us-west-2"
 type = "binary"
 
 [[criterion]]
-name = "instances_ec2_multiregion_ec2_ks84v1fh12_us_east"
+name = "three_instances_share_vpc"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): Instances {{ec2-multiregion-EC2-ks84v1fh12-us-east-1-InstanceId}}, {{ec2-multiregion-EC2-ks84v1fh12-us-east-1-LaunchTemplateInstanceId}}, and {{ec2-multiregion-EC2-ks84v1fh12-us-east-1-PrivateInstanceId}} are in VPC {{ec2-multiregion-EC2-ks84v1fh12-us-east-1-VpcId}}"
 type = "binary"
 
 [[criterion]]
-name = "the_remaining_instance_in_us_east_1_is_in_the_de"
+name = "fourth_instance_in_different_vpc"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The remaining instance in us-east-1 is not in the same VPC as (not network-adjacent to) the other three instances. The reference answer additionally notes this VPC is the account's default VPC -- do not require the junior to use the words 'default VPC' or otherwise identify it as default; crediting the substantive non-adjacency fact is sufficient."
 type = "binary"
 

--- a/tasks/ec2-multiregion/ec-instances-without-default-vpc/tests/judge.toml
+++ b/tasks/ec2-multiregion/ec-instances-without-default-vpc/tests/judge.toml
@@ -13,12 +13,12 @@ description = "Per the rubric, does the junior engineer's answer support this cl
 type = "binary"
 
 [[criterion]]
-name = "us_east_1_launch_template_instance_not_default_vpc"
+name = "us_east_1_launch_template_instance_not_in_default_vpc"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): {{ec2-multiregion-EC2-ks84v1fh12-us-east-1-LaunchTemplateInstanceId}} in us-east-1 is not associated with a default VPC"
 type = "binary"
 
 [[criterion]]
-name = "us_east_1_private_instance_not_default_vpc"
+name = "us_east_1_private_instance_not_in_default_vpc"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): {{ec2-multiregion-EC2-ks84v1fh12-us-east-1-PrivateInstanceId}} in us-east-1 is not associated with a default VPC"
 type = "binary"
 

--- a/tasks/ec2-multiregion/ec-instances-without-default-vpc/tests/judge.toml
+++ b/tasks/ec2-multiregion/ec-instances-without-default-vpc/tests/judge.toml
@@ -8,27 +8,27 @@ prompt_template = "judge_prompt.md"
 mode = "batched"
 
 [[criterion]]
-name = "ec2_multiregion_ec2_ks84v1fh12_us_east_1_instanc"
+name = "us_east_1_instance_not_in_default_vpc"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): {{ec2-multiregion-EC2-ks84v1fh12-us-east-1-InstanceId}} in us-east-1 is not associated with a default VPC"
 type = "binary"
 
 [[criterion]]
-name = "ec2_multiregion_ec2_ks84v1fh12_us_east_1_launcht"
+name = "us_east_1_launch_template_instance_not_default_vpc"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): {{ec2-multiregion-EC2-ks84v1fh12-us-east-1-LaunchTemplateInstanceId}} in us-east-1 is not associated with a default VPC"
 type = "binary"
 
 [[criterion]]
-name = "ec2_multiregion_ec2_ks84v1fh12_us_east_1_private"
+name = "us_east_1_private_instance_not_default_vpc"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): {{ec2-multiregion-EC2-ks84v1fh12-us-east-1-PrivateInstanceId}} in us-east-1 is not associated with a default VPC"
 type = "binary"
 
 [[criterion]]
-name = "ec2_multiregion_ec2_ls9fuhb522_us_west_1_instanc"
+name = "us_west_1_instance_not_in_default_vpc"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): {{ec2-multiregion-EC2-ls9fuhb522-us-west-1-InstanceId}} in us-west-1 is not associated with a default VPC"
 type = "binary"
 
 [[criterion]]
-name = "ec2_multiregion_ec2_ls9fuhb522_us_west_2_instanc"
+name = "us_west_2_instance_not_in_default_vpc"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): {{ec2-multiregion-EC2-ls9fuhb522-us-west-2-InstanceId}} in us-west-2 is not associated with a default VPC"
 type = "binary"
 

--- a/tasks/ec2-multiregion/find-ec-instances-in-public-subnets/tests/judge.toml
+++ b/tasks/ec2-multiregion/find-ec-instances-in-public-subnets/tests/judge.toml
@@ -8,27 +8,27 @@ prompt_template = "judge_prompt.md"
 mode = "batched"
 
 [[criterion]]
-name = "first_instance_public_subnet_us_east_1"
+name = "standalone_instance_in_public_subnet_us_east_1"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): {{ec2-multiregion-EC2-ks84v1fh12-us-east-1-InstanceId}} is an EC2 instance in a public subnet in the us-east-1 region"
 type = "binary"
 
 [[criterion]]
-name = "launch_template_instance_public_subnet_us_east_1"
+name = "launch_template_instance_in_public_subnet_us_east_1"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): {{ec2-multiregion-EC2-ks84v1fh12-us-east-1-LaunchTemplateInstanceId}} is an EC2 instance in a public subnet in the us-east-1 region"
 type = "binary"
 
 [[criterion]]
-name = "default_vpc_instance_public_subnet_us_east_1"
+name = "default_vpc_instance_in_public_subnet_us_east_1"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): {{ec2-multiregion-EC2-ks84v1fh12-us-east-1-DefaultVPCInstanceId}} is an EC2 instance in a public subnet in the us-east-1 region"
 type = "binary"
 
 [[criterion]]
-name = "instance_public_subnet_us_west_1"
+name = "instance_in_public_subnet_us_west_1"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): {{ec2-multiregion-EC2-ls9fuhb522-us-west-1-InstanceId}} is an EC2 instance in a public subnet in the us-west-1 region"
 type = "binary"
 
 [[criterion]]
-name = "instance_public_subnet_us_west_2"
+name = "instance_in_public_subnet_us_west_2"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): {{ec2-multiregion-EC2-ls9fuhb522-us-west-2-InstanceId}} is an EC2 instance in a public subnet in the us-west-2 region"
 type = "binary"
 

--- a/tasks/ec2-multiregion/find-ec-instances-in-public-subnets/tests/judge.toml
+++ b/tasks/ec2-multiregion/find-ec-instances-in-public-subnets/tests/judge.toml
@@ -8,27 +8,27 @@ prompt_template = "judge_prompt.md"
 mode = "batched"
 
 [[criterion]]
-name = "ec2_multiregion_ec2_ks84v1fh12_us_east_1_instanc"
+name = "first_instance_public_subnet_us_east_1"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): {{ec2-multiregion-EC2-ks84v1fh12-us-east-1-InstanceId}} is an EC2 instance in a public subnet in the us-east-1 region"
 type = "binary"
 
 [[criterion]]
-name = "ec2_multiregion_ec2_ks84v1fh12_us_east_1_launcht"
+name = "launch_template_instance_public_subnet_us_east_1"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): {{ec2-multiregion-EC2-ks84v1fh12-us-east-1-LaunchTemplateInstanceId}} is an EC2 instance in a public subnet in the us-east-1 region"
 type = "binary"
 
 [[criterion]]
-name = "ec2_multiregion_ec2_ks84v1fh12_us_east_1_default"
+name = "default_vpc_instance_public_subnet_us_east_1"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): {{ec2-multiregion-EC2-ks84v1fh12-us-east-1-DefaultVPCInstanceId}} is an EC2 instance in a public subnet in the us-east-1 region"
 type = "binary"
 
 [[criterion]]
-name = "ec2_multiregion_ec2_ls9fuhb522_us_west_1_instanc"
+name = "instance_public_subnet_us_west_1"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): {{ec2-multiregion-EC2-ls9fuhb522-us-west-1-InstanceId}} is an EC2 instance in a public subnet in the us-west-1 region"
 type = "binary"
 
 [[criterion]]
-name = "ec2_multiregion_ec2_ls9fuhb522_us_west_2_instanc"
+name = "instance_public_subnet_us_west_2"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): {{ec2-multiregion-EC2-ls9fuhb522-us-west-2-InstanceId}} is an EC2 instance in a public subnet in the us-west-2 region"
 type = "binary"
 

--- a/tasks/ec2-multiregion/list-ec-instances-all-regions-1/tests/judge.toml
+++ b/tasks/ec2-multiregion/list-ec-instances-all-regions-1/tests/judge.toml
@@ -8,17 +8,17 @@ prompt_template = "judge_prompt.md"
 mode = "batched"
 
 [[criterion]]
-name = "ec2_multiregion_ec2_ks84v1fh12_us_east_1_launcht"
+name = "launch_template_instance_ssh_reachable"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): {{ec2-multiregion-EC2-ks84v1fh12-us-east-1-LaunchTemplateInstanceId}} is SSH-reachable from the internet"
 type = "binary"
 
 [[criterion]]
-name = "ec2_multiregion_ec2_ks84v1fh12_us_east_1_instanc"
+name = "standalone_instance_ssh_reachable"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): {{ec2-multiregion-EC2-ks84v1fh12-us-east-1-InstanceId}} is SSH-reachable from the internet"
 type = "binary"
 
 [[criterion]]
-name = "no_other_instances_besides_ec2_multiregion_ec2_k"
+name = "only_two_instances_ssh_reachable"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): No other instances besides {{ec2-multiregion-EC2-ks84v1fh12-us-east-1-LaunchTemplateInstanceId}} and {{ec2-multiregion-EC2-ks84v1fh12-us-east-1-InstanceId}} are SSH-reachable from the internet"
 type = "binary"
 

--- a/tasks/ec2-multiregion/list-ec-instances-all-regions/tests/judge.toml
+++ b/tasks/ec2-multiregion/list-ec-instances-all-regions/tests/judge.toml
@@ -8,7 +8,7 @@ prompt_template = "judge_prompt.md"
 mode = "batched"
 
 [[criterion]]
-name = "us_east_1_has_first_instance"
+name = "us_east_1_has_instance"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): In us-east-1 region you have the EC2 instance {{ec2-multiregion-EC2-ks84v1fh12-us-east-1-InstanceId}}"
 type = "binary"
 

--- a/tasks/ec2-multiregion/list-ec-instances-all-regions/tests/judge.toml
+++ b/tasks/ec2-multiregion/list-ec-instances-all-regions/tests/judge.toml
@@ -8,32 +8,32 @@ prompt_template = "judge_prompt.md"
 mode = "batched"
 
 [[criterion]]
-name = "in_us_east_1_region_you_have_the_ec2_instance_ec"
+name = "us_east_1_has_first_instance"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): In us-east-1 region you have the EC2 instance {{ec2-multiregion-EC2-ks84v1fh12-us-east-1-InstanceId}}"
 type = "binary"
 
 [[criterion]]
-name = "in_us_east_1_region_you_have_the_ec2_instance_ec_2"
+name = "us_east_1_has_launch_template_instance"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): In us-east-1 region you have the EC2 instance {{ec2-multiregion-EC2-ks84v1fh12-us-east-1-LaunchTemplateInstanceId}}"
 type = "binary"
 
 [[criterion]]
-name = "in_us_east_1_region_you_have_the_ec2_instance_ec_3"
+name = "us_east_1_has_default_vpc_instance"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): In us-east-1 region you have the EC2 instance {{ec2-multiregion-EC2-ks84v1fh12-us-east-1-DefaultVPCInstanceId}}"
 type = "binary"
 
 [[criterion]]
-name = "in_us_east_1_region_you_have_the_ec2_instance_ec_4"
+name = "us_east_1_has_private_instance"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): In us-east-1 region you have the EC2 instance {{ec2-multiregion-EC2-ks84v1fh12-us-east-1-PrivateInstanceId}}"
 type = "binary"
 
 [[criterion]]
-name = "in_us_west_1_region_you_have_the_ec2_instance_ec"
+name = "us_west_1_has_instance"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): In us-west-1 region you have the EC2 instance {{ec2-multiregion-EC2-ls9fuhb522-us-west-1-InstanceId}}"
 type = "binary"
 
 [[criterion]]
-name = "in_us_west_2_region_you_have_the_ec2_instance_ec"
+name = "us_west_2_has_instance"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): In us-west-2 region you have the EC2 instance {{ec2-multiregion-EC2-ls9fuhb522-us-west-2-InstanceId}}"
 type = "binary"
 

--- a/tasks/ec2-multiregion/list-ec-instances-by-vpc-across-regions/tests/judge.toml
+++ b/tasks/ec2-multiregion/list-ec-instances-by-vpc-across-regions/tests/judge.toml
@@ -8,32 +8,32 @@ prompt_template = "judge_prompt.md"
 mode = "batched"
 
 [[criterion]]
-name = "first_instance_vpc_region"
+name = "instance_in_vpc_us_east_1"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): Instance {{ec2-multiregion-EC2-ks84v1fh12-us-east-1-InstanceId}} is in VPC {{ec2-multiregion-EC2-ks84v1fh12-us-east-1-VpcId}} in region us-east-1"
 type = "binary"
 
 [[criterion]]
-name = "launch_template_instance_vpc_region"
+name = "launch_template_instance_in_vpc_us_east_1"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): Instance {{ec2-multiregion-EC2-ks84v1fh12-us-east-1-LaunchTemplateInstanceId}} is in VPC {{ec2-multiregion-EC2-ks84v1fh12-us-east-1-VpcId}} in region us-east-1"
 type = "binary"
 
 [[criterion]]
-name = "private_instance_vpc_region"
+name = "private_instance_in_vpc_us_east_1"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): Instance {{ec2-multiregion-EC2-ks84v1fh12-us-east-1-PrivateInstanceId}} is in VPC {{ec2-multiregion-EC2-ks84v1fh12-us-east-1-VpcId}} in region us-east-1"
 type = "binary"
 
 [[criterion]]
-name = "default_vpc_instance_vpc_region"
+name = "default_vpc_instance_in_default_vpc_us_east_1"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): Instance {{ec2-multiregion-EC2-ks84v1fh12-us-east-1-DefaultVPCInstanceId}} is in VPC {{ec2-multiregion-EC2-ks84v1fh12-us-east-1-DefaultVpcId}} in region us-east-1"
 type = "binary"
 
 [[criterion]]
-name = "us_west_1_instance_vpc_region"
+name = "instance_in_vpc_us_west_1"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): Instance {{ec2-multiregion-EC2-ls9fuhb522-us-west-1-InstanceId}} is in VPC {{ec2-multiregion-EC2-ls9fuhb522-us-west-1-VpcId}} in region us-west-1"
 type = "binary"
 
 [[criterion]]
-name = "us_west_2_instance_vpc_region"
+name = "instance_in_vpc_us_west_2"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): Instance {{ec2-multiregion-EC2-ls9fuhb522-us-west-2-InstanceId}} is in VPC {{ec2-multiregion-EC2-ls9fuhb522-us-west-2-VpcId}} in region us-west-2"
 type = "binary"
 

--- a/tasks/ec2-multiregion/list-ec-instances-by-vpc-across-regions/tests/judge.toml
+++ b/tasks/ec2-multiregion/list-ec-instances-by-vpc-across-regions/tests/judge.toml
@@ -8,32 +8,32 @@ prompt_template = "judge_prompt.md"
 mode = "batched"
 
 [[criterion]]
-name = "instance_ec2_multiregion_ec2_ks84v1fh12_us_east_"
+name = "first_instance_vpc_region"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): Instance {{ec2-multiregion-EC2-ks84v1fh12-us-east-1-InstanceId}} is in VPC {{ec2-multiregion-EC2-ks84v1fh12-us-east-1-VpcId}} in region us-east-1"
 type = "binary"
 
 [[criterion]]
-name = "instance_ec2_multiregion_ec2_ks84v1fh12_us_east__2"
+name = "launch_template_instance_vpc_region"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): Instance {{ec2-multiregion-EC2-ks84v1fh12-us-east-1-LaunchTemplateInstanceId}} is in VPC {{ec2-multiregion-EC2-ks84v1fh12-us-east-1-VpcId}} in region us-east-1"
 type = "binary"
 
 [[criterion]]
-name = "instance_ec2_multiregion_ec2_ks84v1fh12_us_east__3"
+name = "private_instance_vpc_region"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): Instance {{ec2-multiregion-EC2-ks84v1fh12-us-east-1-PrivateInstanceId}} is in VPC {{ec2-multiregion-EC2-ks84v1fh12-us-east-1-VpcId}} in region us-east-1"
 type = "binary"
 
 [[criterion]]
-name = "instance_ec2_multiregion_ec2_ks84v1fh12_us_east__4"
+name = "default_vpc_instance_vpc_region"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): Instance {{ec2-multiregion-EC2-ks84v1fh12-us-east-1-DefaultVPCInstanceId}} is in VPC {{ec2-multiregion-EC2-ks84v1fh12-us-east-1-DefaultVpcId}} in region us-east-1"
 type = "binary"
 
 [[criterion]]
-name = "instance_ec2_multiregion_ec2_ls9fuhb522_us_west_"
+name = "us_west_1_instance_vpc_region"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): Instance {{ec2-multiregion-EC2-ls9fuhb522-us-west-1-InstanceId}} is in VPC {{ec2-multiregion-EC2-ls9fuhb522-us-west-1-VpcId}} in region us-west-1"
 type = "binary"
 
 [[criterion]]
-name = "instance_ec2_multiregion_ec2_ls9fuhb522_us_west__2"
+name = "us_west_2_instance_vpc_region"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): Instance {{ec2-multiregion-EC2-ls9fuhb522-us-west-2-InstanceId}} is in VPC {{ec2-multiregion-EC2-ls9fuhb522-us-west-2-VpcId}} in region us-west-2"
 type = "binary"
 

--- a/tasks/ec2-multiregion/list-ec-private-ips-all-regions/tests/judge.toml
+++ b/tasks/ec2-multiregion/list-ec-private-ips-all-regions/tests/judge.toml
@@ -8,32 +8,32 @@ prompt_template = "judge_prompt.md"
 mode = "batched"
 
 [[criterion]]
-name = "in_us_east_1_there_is_an_ec2_instance_ec2_multir"
+name = "us_east_first_instance_exists"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): In us-east-1, there is an EC2 instance {{ec2-multiregion-EC2-ks84v1fh12-us-east-1-InstanceId}} with private IP {{ec2-multiregion-EC2-ks84v1fh12-us-east-1-PrivateIPOfInstanceWithoutLaunchTemplate}}"
 type = "binary"
 
 [[criterion]]
-name = "in_us_east_1_there_is_an_ec2_instance_ec2_multir_2"
+name = "us_east_launch_template_instance_exists"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): In us-east-1, there is an EC2 instance {{ec2-multiregion-EC2-ks84v1fh12-us-east-1-LaunchTemplateInstanceId}} with private IP {{ec2-multiregion-EC2-ks84v1fh12-us-east-1-PrivateIPOfInstanceWithLaunchTemplate}}"
 type = "binary"
 
 [[criterion]]
-name = "in_us_east_1_there_is_an_ec2_instance_ec2_multir_3"
+name = "us_east_default_vpc_instance_exists"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): In us-east-1, there is an EC2 instance {{ec2-multiregion-EC2-ks84v1fh12-us-east-1-DefaultVPCInstanceId}} with private IP {{ec2-multiregion-EC2-ks84v1fh12-us-east-1-PrivateIPOfInstanceWithDefaultVpc}}"
 type = "binary"
 
 [[criterion]]
-name = "in_us_east_1_there_is_an_ec2_instance_ec2_multir_4"
+name = "us_east_private_instance_exists"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): In us-east-1, there is an EC2 instance {{ec2-multiregion-EC2-ks84v1fh12-us-east-1-PrivateInstanceId}} with private IP {{ec2-multiregion-EC2-ks84v1fh12-us-east-1-PrivateInstancePrivateIp}}"
 type = "binary"
 
 [[criterion]]
-name = "in_us_west_1_there_is_an_ec2_instance_ec2_multir"
+name = "us_west_1_instance_exists"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): In us-west-1, there is an EC2 instance {{ec2-multiregion-EC2-ls9fuhb522-us-west-1-InstanceId}} with private IP {{ec2-multiregion-EC2-ls9fuhb522-us-west-1-PrivateIPOfInstance}}"
 type = "binary"
 
 [[criterion]]
-name = "in_us_west_2_there_is_an_ec2_instance_ec2_multir"
+name = "us_west_2_instance_exists"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): In us-west-2, there is an EC2 instance {{ec2-multiregion-EC2-ls9fuhb522-us-west-2-InstanceId}} with private IP {{ec2-multiregion-EC2-ls9fuhb522-us-west-2-PrivateIPOfInstance}}"
 type = "binary"
 

--- a/tasks/ec2-multiregion/list-ec-private-ips-all-regions/tests/judge.toml
+++ b/tasks/ec2-multiregion/list-ec-private-ips-all-regions/tests/judge.toml
@@ -8,22 +8,22 @@ prompt_template = "judge_prompt.md"
 mode = "batched"
 
 [[criterion]]
-name = "us_east_first_instance_exists"
+name = "instance_without_launch_template_exists"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): In us-east-1, there is an EC2 instance {{ec2-multiregion-EC2-ks84v1fh12-us-east-1-InstanceId}} with private IP {{ec2-multiregion-EC2-ks84v1fh12-us-east-1-PrivateIPOfInstanceWithoutLaunchTemplate}}"
 type = "binary"
 
 [[criterion]]
-name = "us_east_launch_template_instance_exists"
+name = "instance_with_launch_template_exists"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): In us-east-1, there is an EC2 instance {{ec2-multiregion-EC2-ks84v1fh12-us-east-1-LaunchTemplateInstanceId}} with private IP {{ec2-multiregion-EC2-ks84v1fh12-us-east-1-PrivateIPOfInstanceWithLaunchTemplate}}"
 type = "binary"
 
 [[criterion]]
-name = "us_east_default_vpc_instance_exists"
+name = "instance_in_default_vpc_exists"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): In us-east-1, there is an EC2 instance {{ec2-multiregion-EC2-ks84v1fh12-us-east-1-DefaultVPCInstanceId}} with private IP {{ec2-multiregion-EC2-ks84v1fh12-us-east-1-PrivateIPOfInstanceWithDefaultVpc}}"
 type = "binary"
 
 [[criterion]]
-name = "us_east_private_instance_exists"
+name = "private_instance_exists"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): In us-east-1, there is an EC2 instance {{ec2-multiregion-EC2-ks84v1fh12-us-east-1-PrivateInstanceId}} with private IP {{ec2-multiregion-EC2-ks84v1fh12-us-east-1-PrivateInstancePrivateIp}}"
 type = "binary"
 

--- a/tasks/ec2-multiregion/list-unused-security-groups-all-regions/tests/judge.toml
+++ b/tasks/ec2-multiregion/list-unused-security-groups-all-regions/tests/judge.toml
@@ -8,17 +8,17 @@ prompt_template = "judge_prompt.md"
 mode = "batched"
 
 [[criterion]]
-name = "you_have_4b68864e_unusedsecuritygroupcount_unuse"
+name = "unused_security_group_count"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): You have {{4b68864e-UnusedSecurityGroupCount}} unused security groups"
 type = "binary"
 
 [[criterion]]
-name = "most_unused_security_groups_are_default_security"
+name = "unused_sgs_are_default_vpc_sgs"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): Most unused security groups are default security groups automatically created for each VPC"
 type = "binary"
 
 [[criterion]]
-name = "in_us_east_1_one_of_the_unused_security_groups_i"
+name = "specific_unused_sg_in_us_east_1"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): In us-east-1, one of the unused security groups is {{ec2-multiregion-EC2-ks84v1fh12-us-east-1-UnusedSecurityGroupId}}"
 type = "binary"
 

--- a/tasks/ec2-multiregion/list-unused-security-groups-all-regions/tests/judge.toml
+++ b/tasks/ec2-multiregion/list-unused-security-groups-all-regions/tests/judge.toml
@@ -13,7 +13,7 @@ description = "Per the rubric, does the junior engineer's answer support this cl
 type = "binary"
 
 [[criterion]]
-name = "unused_sgs_are_default_vpc_sgs"
+name = "unused_sgs_mostly_default"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): Most unused security groups are default security groups automatically created for each VPC"
 type = "binary"
 

--- a/tasks/serverless-apps/check-lambda-layers-s-code/tests/judge.toml
+++ b/tasks/serverless-apps/check-lambda-layers-s-code/tests/judge.toml
@@ -8,7 +8,7 @@ prompt_template = "judge_prompt.md"
 mode = "batched"
 
 [[criterion]]
-name = "serverless_apps_lambdamisc_us_east_1_s3layerarne"
+name = "lambda_layer_uses_s3_hosted_code"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): {{serverless-apps-LambdaMisc-us-east-1-S3LayerArnExport}} is using code hosted on S3"
 type = "binary"
 

--- a/tasks/serverless-apps/check-s-buckets-public-access/tests/judge.toml
+++ b/tasks/serverless-apps/check-s-buckets-public-access/tests/judge.toml
@@ -8,47 +8,47 @@ prompt_template = "judge_prompt.md"
 mode = "batched"
 
 [[criterion]]
-name = "serverless_apps_s3storage_us_east_1_analyticsbuc"
+name = "analytics_bucket_block_public_acls_false"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): {{serverless-apps-S3Storage-us-east-1-AnalyticsBucketName}} has BlockPublicAcls false"
 type = "binary"
 
 [[criterion]]
-name = "serverless_apps_s3storage_us_east_1_analyticsbuc_2"
+name = "analytics_bucket_ignore_public_acls_true"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): {{serverless-apps-S3Storage-us-east-1-AnalyticsBucketName}} has IgnorePublicAcls true"
 type = "binary"
 
 [[criterion]]
-name = "serverless_apps_s3storage_us_east_1_analyticsbuc_3"
+name = "analytics_bucket_block_public_policy_true"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): {{serverless-apps-S3Storage-us-east-1-AnalyticsBucketName}} has BlockPublicPolicy true"
 type = "binary"
 
 [[criterion]]
-name = "serverless_apps_s3storage_us_east_1_analyticsbuc_4"
+name = "analytics_bucket_restrict_public_buckets_true"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): {{serverless-apps-S3Storage-us-east-1-AnalyticsBucketName}} has RestrictPublicBuckets true"
 type = "binary"
 
 [[criterion]]
-name = "every_bucket_other_than_serverless_apps_s3storag"
+name = "other_buckets_have_all_blocks_enabled"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): Every bucket other than {{serverless-apps-S3Storage-us-east-1-AnalyticsBucketName}} has all four public access block settings (BlockPublicAcls, IgnorePublicAcls, BlockPublicPolicy, RestrictPublicBuckets) set to true"
 type = "binary"
 
 [[criterion]]
-name = "the_gap_in_serverless_apps_s3storage_us_east_1_a"
+name = "analytics_bucket_gap_does_not_expose"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The gap in {{serverless-apps-S3Storage-us-east-1-AnalyticsBucketName}} (BlockPublicAcls false while other settings are true) does not actually expose it to public access"
 type = "binary"
 
 [[criterion]]
-name = "ignorepublicacls_true_makes_s3_ignore_any_public"
+name = "ignore_public_acls_prevents_exposure"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): IgnorePublicAcls=true makes S3 ignore any public ACLs that BlockPublicAcls=false would otherwise allow. The instruction only asks whether the gap leaves the bucket exposed, not to enumerate every contributing setting -- credit this claim if the junior correctly concludes/explains the bucket is not exposed via any valid reasoning (e.g. citing Object Ownership settings, BlockPublicPolicy+RestrictPublicBuckets, or the settings as a whole), without requiring IgnorePublicAcls to be named specifically as the mechanism."
 type = "binary"
 
 [[criterion]]
-name = "blockpublicpolicy_true_plus_restrictpublicbucket"
+name = "policy_blocks_prevent_public_access"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): the bucket's overall public-access-block configuration (despite BlockPublicAcls being false) prevents public access via bucket policy or access points. The instruction only asks whether the gap leaves the bucket exposed, not to enumerate every contributing setting -- credit this claim if the junior correctly concludes/explains the bucket is not exposed via any valid reasoning (e.g. citing IgnorePublicAcls, the absence of a bucket policy, or the settings as a whole), without requiring BlockPublicPolicy and RestrictPublicBuckets to be named specifically."
 type = "binary"
 
 [[criterion]]
-name = "none_of_the_buckets_currently_allow_public_acces"
+name = "no_buckets_allow_public_access"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): None of the buckets currently allow public access"
 type = "binary"
 

--- a/tasks/serverless-apps/check-s-lifecycle-tag-filter-rules/tests/judge.toml
+++ b/tasks/serverless-apps/check-s-lifecycle-tag-filter-rules/tests/judge.toml
@@ -8,7 +8,7 @@ prompt_template = "judge_prompt.md"
 mode = "batched"
 
 [[criterion]]
-name = "the_bucket_serverless_apps_s3storage_us_east_1_l"
+name = "bucket_expires_tagged_objects_after_day"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The bucket {{serverless-apps-S3Storage-us-east-1-LifeCycleBucket}} has a lifecycle expiration rule that deletes objects after 1 day when tagged with shouldDelete: true."
 type = "binary"
 

--- a/tasks/serverless-apps/ecs-services-custom-configurations-check/tests/judge.toml
+++ b/tasks/serverless-apps/ecs-services-custom-configurations-check/tests/judge.toml
@@ -8,27 +8,27 @@ prompt_template = "judge_prompt.md"
 mode = "batched"
 
 [[criterion]]
-name = "serverless_apps_ecs_us_east_1_ecsservicename_has"
+name = "service_desired_task_count_is_two"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): {{serverless-apps-ECS-us-east-1-EcsServiceName}} has a desired task count of 2"
 type = "binary"
 
 [[criterion]]
-name = "serverless_apps_ecs_us_east_1_ecsservicename_has_2"
+name = "service_has_public_ip_enabled"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): {{serverless-apps-ECS-us-east-1-EcsServiceName}} has public IP assignment enabled"
 type = "binary"
 
 [[criterion]]
-name = "serverless_apps_ecs_us_east_1_ecsservicename_use"
+name = "service_uses_windows_platform"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): {{serverless-apps-ECS-us-east-1-EcsServiceName}} uses a Windows Server 2019 Full platform, and this is a non-default/customized setting (Fargate's default operating system family is Linux). The instruction specifically asks to check for custom/non-default configurations, so merely stating the platform as a neutral fact (e.g. listing it only under a 'current state' heading, with no indication it is a deviation from default) does NOT satisfy this claim -- credit it only if the junior's answer identifies or treats this platform choice as a customization/deviation from default."
 type = "binary"
 
 [[criterion]]
-name = "serverless_apps_ecs_us_east_1_ecsservicename_has_3"
+name = "service_health_check_grace_sixty_seconds"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): {{serverless-apps-ECS-us-east-1-EcsServiceName}} has a health check grace period of 60 seconds"
 type = "binary"
 
 [[criterion]]
-name = "serverless_apps_ecs_us_east_1_ecsservicename_has_4"
+name = "service_minimum_healthy_percent_fifty"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): {{serverless-apps-ECS-us-east-1-EcsServiceName}} has minimumHealthyPercent set to 50"
 type = "binary"
 

--- a/tasks/serverless-apps/ecs-services-ecr-access-check/tests/judge.toml
+++ b/tasks/serverless-apps/ecs-services-ecr-access-check/tests/judge.toml
@@ -8,12 +8,12 @@ prompt_template = "judge_prompt.md"
 mode = "batched"
 
 [[criterion]]
-name = "the_container_image_used_by_the_service_in_the_e"
+name = "ecs_service_uses_windows_iis_image"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The container image used by the service in the ECS cluster {{serverless-apps-ECS-us-east-1-EcsClusterName}} is mcr.microsoft.com/windows/servercore/iis:windowsservercore-ltsc2019"
 type = "binary"
 
 [[criterion]]
-name = "the_service_cannot_access_the_ecr_repository_my_"
+name = "service_cannot_access_ecr_repo"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The service cannot access the ECR repository my-ecr-repo"
 type = "binary"
 

--- a/tasks/serverless-apps/find-lambda-functions-tagged-blueprint/tests/judge.toml
+++ b/tasks/serverless-apps/find-lambda-functions-tagged-blueprint/tests/judge.toml
@@ -8,7 +8,7 @@ prompt_template = "judge_prompt.md"
 mode = "batched"
 
 [[criterion]]
-name = "the_serverless_apps_lambdamisc_us_east_1_taggedl"
+name = "lambda_has_blueprint_tag"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The {{serverless-apps-LambdaMisc-us-east-1-TaggedLambdaName}} lambda function has the 'lambda-console:blueprint' tag."
 type = "binary"
 

--- a/tasks/serverless-apps/find-metric-streams-excluding-namespace/tests/judge.toml
+++ b/tasks/serverless-apps/find-metric-streams-excluding-namespace/tests/judge.toml
@@ -8,7 +8,7 @@ prompt_template = "judge_prompt.md"
 mode = "batched"
 
 [[criterion]]
-name = "the_metric_stream_serverless_apps_monitoring_us_"
+name = "metric_stream_excludes_ec2_metrics"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The metric stream {{serverless-apps-Monitoring-us-east-1-MetricStreamName}} excludes the metrics CPUUtilization, NetworkIn, NetworkOut, DiskReadBytes, and DiskWriteBytes from the AWS/EC2 namespace."
 type = "binary"
 

--- a/tasks/serverless-apps/find-sns-triggered-lambda-functions/tests/judge.toml
+++ b/tasks/serverless-apps/find-sns-triggered-lambda-functions/tests/judge.toml
@@ -8,7 +8,7 @@ prompt_template = "judge_prompt.md"
 mode = "batched"
 
 [[criterion]]
-name = "serverless_apps_lambdamisc_us_east_1_connectedla"
+name = "lambda_triggered_by_sns_topic"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): {{serverless-apps-LambdaMisc-us-east-1-ConnectedLambdaName}} is triggered by SNS topic {{serverless-apps-LambdaMisc-us-east-1-ConnectedSNSTopicName}}"
 type = "binary"
 

--- a/tasks/serverless-apps/list-s-buckets-with-metrics-tag-filters/tests/judge.toml
+++ b/tasks/serverless-apps/list-s-buckets-with-metrics-tag-filters/tests/judge.toml
@@ -8,7 +8,7 @@ prompt_template = "judge_prompt.md"
 mode = "batched"
 
 [[criterion]]
-name = "the_bucket_serverless_apps_s3storage_us_east_1_m"
+name = "bucket_uses_tag_filters_in_metrics"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The bucket {{serverless-apps-S3Storage-us-east-1-MetricsBucketName}} uses tag filters in its metrics configuration."
 type = "binary"
 

--- a/tasks/serverless-apps/list-s-cross-account-analytics-exports/tests/judge.toml
+++ b/tasks/serverless-apps/list-s-cross-account-analytics-exports/tests/judge.toml
@@ -8,22 +8,22 @@ prompt_template = "judge_prompt.md"
 mode = "batched"
 
 [[criterion]]
-name = "there_is_an_analytics_configuration_named_testan"
+name = "analytics_config_exists_on_bucket"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): There is an analytics configuration named 'testAnalyticsConfiguration' on {{serverless-apps-S3Storage-us-east-1-AnalyticsBucketName}}"
 type = "binary"
 
 [[criterion]]
-name = "the_testanalyticsconfiguration_analytics_configu"
+name = "analytics_destination_account_id"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The 'testAnalyticsConfiguration' analytics configuration's S3BucketDestination sets BucketAccountId to 111122223333"
 type = "binary"
 
 [[criterion]]
-name = "111122223333_is_not_the_account_that_owns_the_so"
+name = "destination_account_differs_from_source"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): 111122223333 is not the account that owns the source bucket {{serverless-apps-S3Storage-us-east-1-AnalyticsBucketName}}"
 type = "binary"
 
 [[criterion]]
-name = "testanalyticsconfiguration_on_serverless_apps_s3"
+name = "only_cross_account_analytics_config"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): 'testAnalyticsConfiguration' on {{serverless-apps-S3Storage-us-east-1-AnalyticsBucketName}} is the only analytics configuration that exports to a different account"
 type = "binary"
 

--- a/tasks/serverless-apps/list-s-inventory-configs-with-prefix/tests/judge.toml
+++ b/tasks/serverless-apps/list-s-inventory-configs-with-prefix/tests/judge.toml
@@ -8,17 +8,17 @@ prompt_template = "judge_prompt.md"
 mode = "batched"
 
 [[criterion]]
-name = "the_inventorybucketinventory0_configuration_on_b"
+name = "inventory_config_missing_destination_prefix"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The 'InventoryBucketInventory0' configuration on bucket {{serverless-apps-S3Storage-us-east-1-InventoryBucketName}} has no Destination.S3BucketDestination.Prefix"
 type = "binary"
 
 [[criterion]]
-name = "the_inventorybucketinventory0_configuration_s_re"
+name = "inventory_reports_land_at_bucket_root"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The 'InventoryBucketInventory0' configuration's reports land at the destination bucket's root rather than under a prefix because it has no Destination.S3BucketDestination.Prefix"
 type = "binary"
 
 [[criterion]]
-name = "the_inventory_data_prefix_on_the_inventorybucket"
+name = "inventory_data_is_source_filter_prefix"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The 'inventory-data' prefix on the 'InventoryBucketInventory0' configuration is the source-side Filter.Prefix (which objects get inventoried), not a destination prefix"
 type = "binary"
 

--- a/tasks/serverless-apps/s-bucket-metrics-tag-filter-check/tests/judge.toml
+++ b/tasks/serverless-apps/s-bucket-metrics-tag-filter-check/tests/judge.toml
@@ -8,12 +8,12 @@ prompt_template = "judge_prompt.md"
 mode = "batched"
 
 [[criterion]]
-name = "the_bucket_serverless_apps_s3storage_us_east_1_m"
+name = "bucket_uses_tag_filters"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): The bucket {{serverless-apps-S3Storage-us-east-1-MetricsBucketName}} uses tag filters."
 type = "binary"
 
 [[criterion]]
-name = "no_downstream_resources_consume_this_tag_filtere"
+name = "no_alarms_consume_tag_filtered_metrics"
 description = "Per the rubric, does the junior engineer's answer support this claim (wording may differ, substance must match): No downstream resources consume this tag-filtered metrics to create alarms."
 type = "binary"
 


### PR DESCRIPTION
## Human-readable criterion names for quickstart + basic

**Summary:** renamed every per-claim judge criterion across all 9 `aws-bench-quickstart` tasks and all 43 `aws-bench-basic` tasks, replacing the auto-generated `name` fields (e.g. `you_have_two_s3_buckets_without_intelligent_tier`) with short, human-readable summary names (e.g. `two_buckets_lack_intelligent_tiering`). Nothing about how a task is graded changes -- only the label attached to each criterion. Purely a readability improvement for anyone reading `judge.toml`, a regrade report, or a disagreement-audit spreadsheet.

**52 files, all `tests/judge.toml` only** (193 insertions, 193 deletions -- only `name = "..."` lines change; `description` fields, `judge_prompt.md`, ground truth, and instructions are untouched). Scope: `ec2-multiregion` (9 quickstart tasks), `databases-and-storage` (30 basic tasks), `serverless-apps` (13 basic tasks).

**Verification:**

1. **No regressions from the ordinal-word bug the tool already had fixed once.** Before committing the basic-tier pass, grepped every new name for `first_`/`second_`/`primary_`/`secondary_`/`one_`/`two_` and manually checked each hit against its claim's actual placeholder: every surviving case either mirrors the placeholder's own semantic name (e.g. `FirstVectorIndex`/`SecondVectorIndex`) or is a literal factual count ("2 items with status active"), not an invented disambiguator.
2. **No scenario-hash leakage.** Grepped all 52 touched files for any name containing a 6+ char hex fragment (the unstable per-deployment scenario-id/hash segment of a `{{placeholder}}`) -- none found.
3. **All 52 `judge.toml` files re-validated as parseable TOML with unique criterion names** (scripted check via `tomllib`, not just visual spot-check).
4. **`shared/judge/scripts/sync.sh --check` passes** (99 tasks total) -- this PR only touches criterion `name` fields, which the sync check doesn't gate on, so this confirms the change didn't accidentally disturb anything the sync tooling does track.
5. **Descriptions are byte-for-byte unchanged.** The renaming tool only rewrites `name = "..."` lines via a two-phase placeholder-swap replacement (avoids a new name colliding with another claim's still-unprocessed old name); it never touches `description`, so every criterion still grades the exact same claim it did before.

