### PR TITLE
fix(verifier): call system rewardkit instead of uvx

### DIFF
--- a/shared/judge/test.sh
+++ b/shared/judge/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?

--- a/tasks/api-and-observability/bedrock-agentcore-runtime-missing-logs/tests/test.sh
+++ b/tasks/api-and-observability/bedrock-agentcore-runtime-missing-logs/tests/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?

--- a/tasks/api-and-observability/bedrock-kb-embedding-model-cfn-deps/tests/test.sh
+++ b/tasks/api-and-observability/bedrock-kb-embedding-model-cfn-deps/tests/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?

--- a/tasks/api-and-observability/cloudfront-distribution-origin-error-diagnosis/tests/test.sh
+++ b/tasks/api-and-observability/cloudfront-distribution-origin-error-diagnosis/tests/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?

--- a/tasks/api-and-observability/cloudfront-oac-s-forbidden-troubleshoot/tests/test.sh
+++ b/tasks/api-and-observability/cloudfront-oac-s-forbidden-troubleshoot/tests/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?

--- a/tasks/api-and-observability/debug-api-gateway-iam-authorization/tests/test.sh
+++ b/tasks/api-and-observability/debug-api-gateway-iam-authorization/tests/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?

--- a/tasks/api-and-observability/debug-websocket-api-backend-response/tests/test.sh
+++ b/tasks/api-and-observability/debug-websocket-api-backend-response/tests/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?

--- a/tasks/api-and-observability/diagnose-alb-five-xx-errors/tests/test.sh
+++ b/tasks/api-and-observability/diagnose-alb-five-xx-errors/tests/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?

--- a/tasks/api-and-observability/diagnose-alb-opensearch-bad-gateway/tests/test.sh
+++ b/tasks/api-and-observability/diagnose-alb-opensearch-bad-gateway/tests/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?

--- a/tasks/api-and-observability/diagnose-cloudwatch-alarm-firing/tests/test.sh
+++ b/tasks/api-and-observability/diagnose-cloudwatch-alarm-firing/tests/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?

--- a/tasks/api-and-observability/diagnose-onyx-lambda-processing-failure/tests/test.sh
+++ b/tasks/api-and-observability/diagnose-onyx-lambda-processing-failure/tests/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?

--- a/tasks/api-and-observability/diagnose-xray-service-latency-cause/tests/test.sh
+++ b/tasks/api-and-observability/diagnose-xray-service-latency-cause/tests/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?

--- a/tasks/api-and-observability/find-missing-step-functions-state-machine/tests/test.sh
+++ b/tasks/api-and-observability/find-missing-step-functions-state-machine/tests/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?

--- a/tasks/api-and-observability/lambda-sqs-reconciliation-no-output/tests/test.sh
+++ b/tasks/api-and-observability/lambda-sqs-reconciliation-no-output/tests/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?

--- a/tasks/api-and-observability/opensearch-check-document-request-status-logs/tests/test.sh
+++ b/tasks/api-and-observability/opensearch-check-document-request-status-logs/tests/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?

--- a/tasks/api-and-observability/opensearch-cognito-alb-timeout-diagnosis/tests/test.sh
+++ b/tasks/api-and-observability/opensearch-cognito-alb-timeout-diagnosis/tests/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?

--- a/tasks/compute-and-data/amplify-deploy-frontend-from-s3/tests/test.sh
+++ b/tasks/compute-and-data/amplify-deploy-frontend-from-s3/tests/test.sh
@@ -8,4 +8,4 @@
 # and for the @criterion calls that hit AWS.
 set -ex
 
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+rewardkit /tests

--- a/tasks/compute-and-data/analyze-b2b-commerce-summary-and-lifecycle/tests/test.sh
+++ b/tasks/compute-and-data/analyze-b2b-commerce-summary-and-lifecycle/tests/test.sh
@@ -3,4 +3,4 @@
 # boto3 transitively pulls in botocore for any rewardkit dep that needs it.
 set -ex
 
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+rewardkit /tests

--- a/tasks/compute-and-data/appstream-stack-with-streaming-vpce/tests/test.sh
+++ b/tasks/compute-and-data/appstream-stack-with-streaming-vpce/tests/test.sh
@@ -8,4 +8,4 @@
 # and for the @criterion calls that hit AWS.
 set -ex
 
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+rewardkit /tests

--- a/tasks/compute-and-data/athena-table-cloudfront-logs/tests/test.sh
+++ b/tasks/compute-and-data/athena-table-cloudfront-logs/tests/test.sh
@@ -8,4 +8,4 @@
 # and for the @criterion calls that hit AWS.
 set -ex
 
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+rewardkit /tests

--- a/tasks/compute-and-data/create-athena-tables-from-s3/tests/test.sh
+++ b/tasks/compute-and-data/create-athena-tables-from-s3/tests/test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 set -x
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+rewardkit /tests

--- a/tasks/compute-and-data/create-dynamodb-tables-from-csv/tests/test.sh
+++ b/tasks/compute-and-data/create-dynamodb-tables-from-csv/tests/test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 set -x
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+rewardkit /tests

--- a/tasks/compute-and-data/create-eks-cluster/tests/test.sh
+++ b/tasks/compute-and-data/create-eks-cluster/tests/test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 set -x
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+rewardkit /tests

--- a/tasks/compute-and-data/create-emr-cluster-multi-master/tests/test.sh
+++ b/tasks/compute-and-data/create-emr-cluster-multi-master/tests/test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 set -x
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+rewardkit /tests

--- a/tasks/compute-and-data/create-medialive-channel/tests/test.sh
+++ b/tasks/compute-and-data/create-medialive-channel/tests/test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 set -x
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+rewardkit /tests

--- a/tasks/compute-and-data/create-s3-bucket-with-config/tests/test.sh
+++ b/tasks/compute-and-data/create-s3-bucket-with-config/tests/test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 set -x
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+rewardkit /tests

--- a/tasks/compute-and-data/create-s3-tables-with-compaction/tests/test.sh
+++ b/tasks/compute-and-data/create-s3-tables-with-compaction/tests/test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 set -x
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+rewardkit /tests

--- a/tasks/compute-and-data/create-vpc-valkey-dynamodb/tests/test.sh
+++ b/tasks/compute-and-data/create-vpc-valkey-dynamodb/tests/test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 set -x
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+rewardkit /tests

--- a/tasks/compute-and-data/deploy-ec2-instance-with-ebs/tests/test.sh
+++ b/tasks/compute-and-data/deploy-ec2-instance-with-ebs/tests/test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 set -x
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+rewardkit /tests

--- a/tasks/compute-and-data/dynamodb-strip-ec2-fields-from-prod/tests/test.sh
+++ b/tasks/compute-and-data/dynamodb-strip-ec2-fields-from-prod/tests/test.sh
@@ -8,4 +8,4 @@
 # and for the @criterion calls that hit AWS.
 set -ex
 
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+rewardkit /tests

--- a/tasks/compute-and-data/ec2-image-builder-pipeline/tests/test.sh
+++ b/tasks/compute-and-data/ec2-image-builder-pipeline/tests/test.sh
@@ -8,4 +8,4 @@
 # and for the @criterion calls that hit AWS.
 set -ex
 
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+rewardkit /tests

--- a/tasks/compute-and-data/expand-elasticsearch-cfn-template/tests/test.sh
+++ b/tasks/compute-and-data/expand-elasticsearch-cfn-template/tests/test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 set -x
-uvx --from harbor-rewardkit --with boto3 --with pyyaml rewardkit /tests
+rewardkit /tests

--- a/tasks/compute-and-data/install-efs-csi-fips/tests/test.sh
+++ b/tasks/compute-and-data/install-efs-csi-fips/tests/test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 set -x
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+rewardkit /tests

--- a/tasks/compute-and-data/invalidate-cloudfront-cache/tests/test.sh
+++ b/tasks/compute-and-data/invalidate-cloudfront-cache/tests/test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 set -x
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+rewardkit /tests

--- a/tasks/compute-and-data/ipam-pool-and-vpc/tests/test.sh
+++ b/tasks/compute-and-data/ipam-pool-and-vpc/tests/test.sh
@@ -8,4 +8,4 @@
 # and for the @criterion calls that hit AWS.
 set -ex
 
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+rewardkit /tests

--- a/tasks/compute-and-data/kinesis-flink-studio-realtime/tests/test.sh
+++ b/tasks/compute-and-data/kinesis-flink-studio-realtime/tests/test.sh
@@ -8,4 +8,4 @@
 # and for the @criterion calls that hit AWS.
 set -ex
 
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+rewardkit /tests

--- a/tasks/compute-and-data/lambda-versioned-alias-update/tests/test.sh
+++ b/tasks/compute-and-data/lambda-versioned-alias-update/tests/test.sh
@@ -8,4 +8,4 @@
 # and for the @criterion calls that hit AWS.
 set -ex
 
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+rewardkit /tests

--- a/tasks/compute-and-data/manage-buckets-eks-sagemaker/tests/test.sh
+++ b/tasks/compute-and-data/manage-buckets-eks-sagemaker/tests/test.sh
@@ -8,4 +8,4 @@
 # and for the @criterion calls that hit AWS.
 set -ex
 
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+rewardkit /tests

--- a/tasks/compute-and-data/managed-ad-with-ldaps-and-resets/tests/test.sh
+++ b/tasks/compute-and-data/managed-ad-with-ldaps-and-resets/tests/test.sh
@@ -8,4 +8,4 @@
 # and for the @criterion calls that hit AWS.
 set -ex
 
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+rewardkit /tests

--- a/tasks/compute-and-data/move-s3-contents-and-cleanup/tests/test.sh
+++ b/tasks/compute-and-data/move-s3-contents-and-cleanup/tests/test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 set -x
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+rewardkit /tests

--- a/tasks/compute-and-data/move-s3-contents-within-bucket/tests/test.sh
+++ b/tasks/compute-and-data/move-s3-contents-within-bucket/tests/test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 set -x
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+rewardkit /tests

--- a/tasks/compute-and-data/serverless-stripe-api-with-stream/tests/test.sh
+++ b/tasks/compute-and-data/serverless-stripe-api-with-stream/tests/test.sh
@@ -8,4 +8,4 @@
 # and for the @criterion calls that hit AWS.
 set -ex
 
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+rewardkit /tests

--- a/tasks/compute-and-data/sync-s3-buckets-with-metadata/tests/test.sh
+++ b/tasks/compute-and-data/sync-s3-buckets-with-metadata/tests/test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 set -x
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+rewardkit /tests

--- a/tasks/databases-and-storage/analyze-s-intelligent-tiering-configs/tests/test.sh
+++ b/tasks/databases-and-storage/analyze-s-intelligent-tiering-configs/tests/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?

--- a/tasks/databases-and-storage/check-codebuild-project-nodejs-version/tests/test.sh
+++ b/tasks/databases-and-storage/check-codebuild-project-nodejs-version/tests/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?

--- a/tasks/databases-and-storage/check-s-bucket-access-profiles/tests/test.sh
+++ b/tasks/databases-and-storage/check-s-bucket-access-profiles/tests/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?

--- a/tasks/databases-and-storage/check-s-vector-bucket-indexes-exist/tests/test.sh
+++ b/tasks/databases-and-storage/check-s-vector-bucket-indexes-exist/tests/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?

--- a/tasks/databases-and-storage/cloudformation-top-stacks-resource-breakdown/tests/test.sh
+++ b/tasks/databases-and-storage/cloudformation-top-stacks-resource-breakdown/tests/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?

--- a/tasks/databases-and-storage/compare-s-bucket-structure-sizes/tests/test.sh
+++ b/tasks/databases-and-storage/compare-s-bucket-structure-sizes/tests/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?

--- a/tasks/databases-and-storage/count-cfn-stacks-with-s-buckets/tests/test.sh
+++ b/tasks/databases-and-storage/count-cfn-stacks-with-s-buckets/tests/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?

--- a/tasks/databases-and-storage/count-old-s-buckets/tests/test.sh
+++ b/tasks/databases-and-storage/count-old-s-buckets/tests/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?

--- a/tasks/databases-and-storage/count-sns-topic-sqs-subscribers/tests/test.sh
+++ b/tasks/databases-and-storage/count-sns-topic-sqs-subscribers/tests/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?

--- a/tasks/databases-and-storage/count-windows-server-managed-nodes/tests/test.sh
+++ b/tasks/databases-and-storage/count-windows-server-managed-nodes/tests/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?

--- a/tasks/databases-and-storage/dynamodb-query-workflow-status-analysis/tests/test.sh
+++ b/tasks/databases-and-storage/dynamodb-query-workflow-status-analysis/tests/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?

--- a/tasks/databases-and-storage/dynamodb-scan-and-fetch-record/tests/test.sh
+++ b/tasks/databases-and-storage/dynamodb-scan-and-fetch-record/tests/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?

--- a/tasks/databases-and-storage/dynamodb-scan-filter-by-attribute/tests/test.sh
+++ b/tasks/databases-and-storage/dynamodb-scan-filter-by-attribute/tests/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?

--- a/tasks/databases-and-storage/dynamodb-tables-resource-based-policy/tests/test.sh
+++ b/tasks/databases-and-storage/dynamodb-tables-resource-based-policy/tests/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?

--- a/tasks/databases-and-storage/estimate-ec-running-instance-costs/tests/test.sh
+++ b/tasks/databases-and-storage/estimate-ec-running-instance-costs/tests/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?

--- a/tasks/databases-and-storage/get-s-bucket-ownership-controls/tests/test.sh
+++ b/tasks/databases-and-storage/get-s-bucket-ownership-controls/tests/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?

--- a/tasks/databases-and-storage/glue-database-tables-schema-details/tests/test.sh
+++ b/tasks/databases-and-storage/glue-database-tables-schema-details/tests/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?

--- a/tasks/databases-and-storage/investigate-athena-table-creation-origin/tests/test.sh
+++ b/tasks/databases-and-storage/investigate-athena-table-creation-origin/tests/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?

--- a/tasks/databases-and-storage/list-buckets-with-lifecycle-policy/tests/test.sh
+++ b/tasks/databases-and-storage/list-buckets-with-lifecycle-policy/tests/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?

--- a/tasks/databases-and-storage/list-dynamodb-kinesis-streams-all-regions/tests/test.sh
+++ b/tasks/databases-and-storage/list-dynamodb-kinesis-streams-all-regions/tests/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?

--- a/tasks/databases-and-storage/list-dynamodb-tables-all-regions/tests/test.sh
+++ b/tasks/databases-and-storage/list-dynamodb-tables-all-regions/tests/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?

--- a/tasks/databases-and-storage/list-s-bucket-subdirectories/tests/test.sh
+++ b/tasks/databases-and-storage/list-s-bucket-subdirectories/tests/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?

--- a/tasks/databases-and-storage/list-waf-webacl-findings/tests/test.sh
+++ b/tasks/databases-and-storage/list-waf-webacl-findings/tests/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?

--- a/tasks/databases-and-storage/query-dynamodb-filtered-records-count/tests/test.sh
+++ b/tasks/databases-and-storage/query-dynamodb-filtered-records-count/tests/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?

--- a/tasks/databases-and-storage/report-unencrypted-s-buckets/tests/test.sh
+++ b/tasks/databases-and-storage/report-unencrypted-s-buckets/tests/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?

--- a/tasks/databases-and-storage/retrieve-s-csv-object-contents/tests/test.sh
+++ b/tasks/databases-and-storage/retrieve-s-csv-object-contents/tests/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?

--- a/tasks/databases-and-storage/retrieve-s-text-file-contents/tests/test.sh
+++ b/tasks/databases-and-storage/retrieve-s-text-file-contents/tests/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?

--- a/tasks/databases-and-storage/s-download-csv-identify-columns/tests/test.sh
+++ b/tasks/databases-and-storage/s-download-csv-identify-columns/tests/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?

--- a/tasks/databases-and-storage/s-object-versions-and-metadata/tests/test.sh
+++ b/tasks/databases-and-storage/s-object-versions-and-metadata/tests/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?

--- a/tasks/databases-and-storage/scan-dynamodb-table-by-status/tests/test.sh
+++ b/tasks/databases-and-storage/scan-dynamodb-table-by-status/tests/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?

--- a/tasks/ec2-multiregion/describe-cloudformation-stack-resources/tests/test.sh
+++ b/tasks/ec2-multiregion/describe-cloudformation-stack-resources/tests/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?

--- a/tasks/ec2-multiregion/describe-ec-instances-cross-region-connectivity/tests/test.sh
+++ b/tasks/ec2-multiregion/describe-ec-instances-cross-region-connectivity/tests/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?

--- a/tasks/ec2-multiregion/ec-instances-without-default-vpc/tests/test.sh
+++ b/tasks/ec2-multiregion/ec-instances-without-default-vpc/tests/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?

--- a/tasks/ec2-multiregion/find-ec-instances-in-public-subnets/tests/test.sh
+++ b/tasks/ec2-multiregion/find-ec-instances-in-public-subnets/tests/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?

--- a/tasks/ec2-multiregion/list-ec-instances-all-regions-1/tests/test.sh
+++ b/tasks/ec2-multiregion/list-ec-instances-all-regions-1/tests/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?

--- a/tasks/ec2-multiregion/list-ec-instances-all-regions/tests/test.sh
+++ b/tasks/ec2-multiregion/list-ec-instances-all-regions/tests/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?

--- a/tasks/ec2-multiregion/list-ec-instances-by-vpc-across-regions/tests/test.sh
+++ b/tasks/ec2-multiregion/list-ec-instances-by-vpc-across-regions/tests/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?

--- a/tasks/ec2-multiregion/list-ec-private-ips-all-regions/tests/test.sh
+++ b/tasks/ec2-multiregion/list-ec-private-ips-all-regions/tests/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?

--- a/tasks/ec2-multiregion/list-unused-security-groups-all-regions/tests/test.sh
+++ b/tasks/ec2-multiregion/list-unused-security-groups-all-regions/tests/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?

--- a/tasks/reference-architectures/analyze-stepfunctions-job-poller-loop/environment/Dockerfile
+++ b/tasks/reference-architectures/analyze-stepfunctions-job-poller-loop/environment/Dockerfile
@@ -19,4 +19,7 @@ RUN ARCH=$(uname -m) && \
     /tmp/aws/install && \
     rm -rf /tmp/aws /tmp/awscliv2.zip
 
+# Pre-install verifier dependencies
+RUN uv pip install --system --no-cache harbor-rewardkit boto3 pyyaml
+
 WORKDIR /app

--- a/tasks/reference-architectures/analyze-stepfunctions-job-poller-loop/tests/test.sh
+++ b/tasks/reference-architectures/analyze-stepfunctions-job-poller-loop/tests/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?

--- a/tasks/reference-architectures/audit-cognito-account-recovery/environment/Dockerfile
+++ b/tasks/reference-architectures/audit-cognito-account-recovery/environment/Dockerfile
@@ -19,4 +19,7 @@ RUN ARCH=$(uname -m) && \
     /tmp/aws/install && \
     rm -rf /tmp/aws /tmp/awscliv2.zip
 
+# Pre-install verifier dependencies
+RUN uv pip install --system --no-cache harbor-rewardkit boto3 pyyaml
+
 WORKDIR /app

--- a/tasks/reference-architectures/audit-cognito-account-recovery/tests/test.sh
+++ b/tasks/reference-architectures/audit-cognito-account-recovery/tests/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?

--- a/tasks/reference-architectures/diagnose-batch-job-no-logs/environment/Dockerfile
+++ b/tasks/reference-architectures/diagnose-batch-job-no-logs/environment/Dockerfile
@@ -19,4 +19,7 @@ RUN ARCH=$(uname -m) && \
     /tmp/aws/install && \
     rm -rf /tmp/aws /tmp/awscliv2.zip
 
+# Pre-install verifier dependencies
+RUN uv pip install --system --no-cache harbor-rewardkit boto3 pyyaml
+
 WORKDIR /app

--- a/tasks/reference-architectures/diagnose-batch-job-no-logs/tests/test.sh
+++ b/tasks/reference-architectures/diagnose-batch-job-no-logs/tests/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?

--- a/tasks/reference-architectures/diagnose-glue-pipeline-not-running/environment/Dockerfile
+++ b/tasks/reference-architectures/diagnose-glue-pipeline-not-running/environment/Dockerfile
@@ -19,4 +19,7 @@ RUN ARCH=$(uname -m) && \
     /tmp/aws/install && \
     rm -rf /tmp/aws /tmp/awscliv2.zip
 
+# Pre-install verifier dependencies
+RUN uv pip install --system --no-cache harbor-rewardkit boto3 pyyaml
+
 WORKDIR /app

--- a/tasks/reference-architectures/diagnose-glue-pipeline-not-running/tests/test.sh
+++ b/tasks/reference-architectures/diagnose-glue-pipeline-not-running/tests/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?

--- a/tasks/reference-architectures/diagnose-rabbitmq-consumer-failure/environment/Dockerfile
+++ b/tasks/reference-architectures/diagnose-rabbitmq-consumer-failure/environment/Dockerfile
@@ -19,4 +19,7 @@ RUN ARCH=$(uname -m) && \
     /tmp/aws/install && \
     rm -rf /tmp/aws /tmp/awscliv2.zip
 
+# Pre-install verifier dependencies
+RUN uv pip install --system --no-cache harbor-rewardkit boto3 pyyaml
+
 WORKDIR /app

--- a/tasks/reference-architectures/diagnose-rabbitmq-consumer-failure/tests/test.sh
+++ b/tasks/reference-architectures/diagnose-rabbitmq-consumer-failure/tests/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?

--- a/tasks/reference-architectures/diagnose-rekognition-reupload-stale/environment/Dockerfile
+++ b/tasks/reference-architectures/diagnose-rekognition-reupload-stale/environment/Dockerfile
@@ -19,4 +19,7 @@ RUN ARCH=$(uname -m) && \
     /tmp/aws/install && \
     rm -rf /tmp/aws /tmp/awscliv2.zip
 
+# Pre-install verifier dependencies
+RUN uv pip install --system --no-cache harbor-rewardkit boto3 pyyaml
+
 WORKDIR /app

--- a/tasks/reference-architectures/diagnose-rekognition-reupload-stale/tests/test.sh
+++ b/tasks/reference-architectures/diagnose-rekognition-reupload-stale/tests/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?

--- a/tasks/reference-architectures/diagnose-s3-event-notification-break/environment/Dockerfile
+++ b/tasks/reference-architectures/diagnose-s3-event-notification-break/environment/Dockerfile
@@ -19,4 +19,7 @@ RUN ARCH=$(uname -m) && \
     /tmp/aws/install && \
     rm -rf /tmp/aws /tmp/awscliv2.zip
 
+# Pre-install verifier dependencies
+RUN uv pip install --system --no-cache harbor-rewardkit boto3 pyyaml
+
 WORKDIR /app

--- a/tasks/reference-architectures/diagnose-s3-event-notification-break/tests/test.sh
+++ b/tasks/reference-architectures/diagnose-s3-event-notification-break/tests/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?

--- a/tasks/reference-architectures/diagnose-sftp-alarm-not-firing/environment/Dockerfile
+++ b/tasks/reference-architectures/diagnose-sftp-alarm-not-firing/environment/Dockerfile
@@ -19,4 +19,7 @@ RUN ARCH=$(uname -m) && \
     /tmp/aws/install && \
     rm -rf /tmp/aws /tmp/awscliv2.zip
 
+# Pre-install verifier dependencies
+RUN uv pip install --system --no-cache harbor-rewardkit boto3 pyyaml
+
 WORKDIR /app

--- a/tasks/reference-architectures/diagnose-sftp-alarm-not-firing/tests/test.sh
+++ b/tasks/reference-architectures/diagnose-sftp-alarm-not-firing/tests/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?

--- a/tasks/reference-architectures/review-aurora-production-readiness/environment/Dockerfile
+++ b/tasks/reference-architectures/review-aurora-production-readiness/environment/Dockerfile
@@ -19,4 +19,7 @@ RUN ARCH=$(uname -m) && \
     /tmp/aws/install && \
     rm -rf /tmp/aws /tmp/awscliv2.zip
 
+# Pre-install verifier dependencies
+RUN uv pip install --system --no-cache harbor-rewardkit boto3 pyyaml
+
 WORKDIR /app

--- a/tasks/reference-architectures/review-aurora-production-readiness/tests/test.sh
+++ b/tasks/reference-architectures/review-aurora-production-readiness/tests/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?

--- a/tasks/reference-architectures/review-backup-plan-cross-region/environment/Dockerfile
+++ b/tasks/reference-architectures/review-backup-plan-cross-region/environment/Dockerfile
@@ -19,4 +19,7 @@ RUN ARCH=$(uname -m) && \
     /tmp/aws/install && \
     rm -rf /tmp/aws /tmp/awscliv2.zip
 
+# Pre-install verifier dependencies
+RUN uv pip install --system --no-cache harbor-rewardkit boto3 pyyaml
+
 WORKDIR /app

--- a/tasks/reference-architectures/review-backup-plan-cross-region/tests/test.sh
+++ b/tasks/reference-architectures/review-backup-plan-cross-region/tests/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?

--- a/tasks/reference-architectures/trace-ec2-ssh-access-path/environment/Dockerfile
+++ b/tasks/reference-architectures/trace-ec2-ssh-access-path/environment/Dockerfile
@@ -19,4 +19,7 @@ RUN ARCH=$(uname -m) && \
     /tmp/aws/install && \
     rm -rf /tmp/aws /tmp/awscliv2.zip
 
+# Pre-install verifier dependencies
+RUN uv pip install --system --no-cache harbor-rewardkit boto3 pyyaml
+
 WORKDIR /app

--- a/tasks/reference-architectures/trace-ec2-ssh-access-path/tests/test.sh
+++ b/tasks/reference-architectures/trace-ec2-ssh-access-path/tests/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?

--- a/tasks/serverless-apps/check-lambda-layers-s-code/tests/test.sh
+++ b/tasks/serverless-apps/check-lambda-layers-s-code/tests/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?

--- a/tasks/serverless-apps/check-s-buckets-public-access/tests/test.sh
+++ b/tasks/serverless-apps/check-s-buckets-public-access/tests/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?

--- a/tasks/serverless-apps/check-s-lifecycle-tag-filter-rules/tests/test.sh
+++ b/tasks/serverless-apps/check-s-lifecycle-tag-filter-rules/tests/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?

--- a/tasks/serverless-apps/ecs-services-custom-configurations-check/tests/test.sh
+++ b/tasks/serverless-apps/ecs-services-custom-configurations-check/tests/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?

--- a/tasks/serverless-apps/ecs-services-ecr-access-check/tests/test.sh
+++ b/tasks/serverless-apps/ecs-services-ecr-access-check/tests/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?

--- a/tasks/serverless-apps/find-lambda-functions-tagged-blueprint/tests/test.sh
+++ b/tasks/serverless-apps/find-lambda-functions-tagged-blueprint/tests/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?

--- a/tasks/serverless-apps/find-metric-streams-excluding-namespace/tests/test.sh
+++ b/tasks/serverless-apps/find-metric-streams-excluding-namespace/tests/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?

--- a/tasks/serverless-apps/find-sns-triggered-lambda-functions/tests/test.sh
+++ b/tasks/serverless-apps/find-sns-triggered-lambda-functions/tests/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?

--- a/tasks/serverless-apps/list-s-buckets-website-hosting/tests/test.sh
+++ b/tasks/serverless-apps/list-s-buckets-website-hosting/tests/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?

--- a/tasks/serverless-apps/list-s-buckets-with-metrics-tag-filters/tests/test.sh
+++ b/tasks/serverless-apps/list-s-buckets-with-metrics-tag-filters/tests/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?

--- a/tasks/serverless-apps/list-s-cross-account-analytics-exports/tests/test.sh
+++ b/tasks/serverless-apps/list-s-cross-account-analytics-exports/tests/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?

--- a/tasks/serverless-apps/list-s-inventory-configs-with-prefix/tests/test.sh
+++ b/tasks/serverless-apps/list-s-inventory-configs-with-prefix/tests/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?

--- a/tasks/serverless-apps/s-bucket-metrics-tag-filter-check/tests/test.sh
+++ b/tasks/serverless-apps/s-bucket-metrics-tag-filter-check/tests/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?

--- a/tasks/streaming-and-iot/connect-create-customer-profiles/tests/test.sh
+++ b/tasks/streaming-and-iot/connect-create-customer-profiles/tests/test.sh
@@ -8,4 +8,4 @@
 # and for the @criterion calls that hit AWS.
 set -ex
 
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+rewardkit /tests

--- a/tasks/streaming-and-iot/ecs-on-ec2-with-cloudmap/tests/test.sh
+++ b/tasks/streaming-and-iot/ecs-on-ec2-with-cloudmap/tests/test.sh
@@ -8,4 +8,4 @@
 # and for the @criterion calls that hit AWS.
 set -ex
 
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+rewardkit /tests

--- a/tasks/streaming-and-iot/health-eventbridge-csv-export/tests/test.sh
+++ b/tasks/streaming-and-iot/health-eventbridge-csv-export/tests/test.sh
@@ -8,4 +8,4 @@
 # and for the @criterion calls that hit AWS.
 set -ex
 
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+rewardkit /tests

--- a/tasks/streaming-and-iot/iot-thing-restrict-vpce-ipv4/tests/test.sh
+++ b/tasks/streaming-and-iot/iot-thing-restrict-vpce-ipv4/tests/test.sh
@@ -8,4 +8,4 @@
 # and for the @criterion calls that hit AWS.
 set -ex
 
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+rewardkit /tests

--- a/tasks/streaming-and-iot/iotsitewise-windfarm-rollup-models/tests/test.sh
+++ b/tasks/streaming-and-iot/iotsitewise-windfarm-rollup-models/tests/test.sh
@@ -8,4 +8,4 @@
 # and for the @criterion calls that hit AWS.
 set -ex
 
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+rewardkit /tests

--- a/tasks/streaming-and-iot/kds-firehose-iceberg-athena/tests/test.sh
+++ b/tasks/streaming-and-iot/kds-firehose-iceberg-athena/tests/test.sh
@@ -8,4 +8,4 @@
 # and for the @criterion calls that hit AWS.
 set -ex
 
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+rewardkit /tests

--- a/tasks/streaming-and-iot/neptune-bulk-load-and-shortest-path/tests/test.sh
+++ b/tasks/streaming-and-iot/neptune-bulk-load-and-shortest-path/tests/test.sh
@@ -8,4 +8,4 @@
 # and for the @criterion calls that hit AWS.
 set -ex
 
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+rewardkit /tests

--- a/tasks/streaming-and-iot/s3-csv-to-xlsx-lambda-pipeline/tests/test.sh
+++ b/tasks/streaming-and-iot/s3-csv-to-xlsx-lambda-pipeline/tests/test.sh
@@ -8,4 +8,4 @@
 # and for the @criterion calls that hit AWS.
 set -ex
 
-uvx --from harbor-rewardkit --with boto3 rewardkit /tests
+rewardkit /tests

--- a/tasks/troubleshooting-multiservice/asg-instance-health-check-failure/tests/test.sh
+++ b/tasks/troubleshooting-multiservice/asg-instance-health-check-failure/tests/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?

--- a/tasks/troubleshooting-multiservice/asg-secondary-network-interface-attach-failure/tests/test.sh
+++ b/tasks/troubleshooting-multiservice/asg-secondary-network-interface-attach-failure/tests/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?

--- a/tasks/troubleshooting-multiservice/check-vpc-flow-log-destinations/tests/test.sh
+++ b/tasks/troubleshooting-multiservice/check-vpc-flow-log-destinations/tests/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?

--- a/tasks/troubleshooting-multiservice/diagnose-asg-instance-issues/tests/test.sh
+++ b/tasks/troubleshooting-multiservice/diagnose-asg-instance-issues/tests/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?

--- a/tasks/troubleshooting-multiservice/diagnose-auto-scaling-group-launch-failure/tests/test.sh
+++ b/tasks/troubleshooting-multiservice/diagnose-auto-scaling-group-launch-failure/tests/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?

--- a/tasks/troubleshooting-multiservice/diagnose-ecs-cluster-no-traffic/tests/test.sh
+++ b/tasks/troubleshooting-multiservice/diagnose-ecs-cluster-no-traffic/tests/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?

--- a/tasks/troubleshooting-multiservice/diagnose-ecs-service-no-running-tasks-1/tests/test.sh
+++ b/tasks/troubleshooting-multiservice/diagnose-ecs-service-no-running-tasks-1/tests/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?

--- a/tasks/troubleshooting-multiservice/diagnose-emr-cluster-performance-issues/tests/test.sh
+++ b/tasks/troubleshooting-multiservice/diagnose-emr-cluster-performance-issues/tests/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?

--- a/tasks/troubleshooting-multiservice/diagnose-redshift-cluster-health-issues/tests/test.sh
+++ b/tasks/troubleshooting-multiservice/diagnose-redshift-cluster-health-issues/tests/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?

--- a/tasks/troubleshooting-multiservice/diagnose-step-functions-failing-executions/tests/test.sh
+++ b/tasks/troubleshooting-multiservice/diagnose-step-functions-failing-executions/tests/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?

--- a/tasks/troubleshooting-multiservice/ec-instance-security-vulnerability-scan/tests/test.sh
+++ b/tasks/troubleshooting-multiservice/ec-instance-security-vulnerability-scan/tests/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?

--- a/tasks/troubleshooting-multiservice/ec-secrets-manager-exit-code-error/tests/test.sh
+++ b/tasks/troubleshooting-multiservice/ec-secrets-manager-exit-code-error/tests/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?

--- a/tasks/troubleshooting-multiservice/ecs-elasticache-transit-gateway-connectivity/tests/test.sh
+++ b/tasks/troubleshooting-multiservice/ecs-elasticache-transit-gateway-connectivity/tests/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?

--- a/tasks/troubleshooting-multiservice/ecs-service-deployment-failure-diagnosis/tests/test.sh
+++ b/tasks/troubleshooting-multiservice/ecs-service-deployment-failure-diagnosis/tests/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?

--- a/tasks/troubleshooting-multiservice/eventbridge-ecs-task-trigger-debugging/tests/test.sh
+++ b/tasks/troubleshooting-multiservice/eventbridge-ecs-task-trigger-debugging/tests/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?

--- a/tasks/troubleshooting-multiservice/fix-cloudformation-update-failed-stack/tests/test.sh
+++ b/tasks/troubleshooting-multiservice/fix-cloudformation-update-failed-stack/tests/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?

--- a/tasks/troubleshooting-multiservice/glue-job-wrong-deployment-region/tests/test.sh
+++ b/tasks/troubleshooting-multiservice/glue-job-wrong-deployment-region/tests/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?

--- a/tasks/troubleshooting-multiservice/lambda-appconfig-stale-value-troubleshoot/tests/test.sh
+++ b/tasks/troubleshooting-multiservice/lambda-appconfig-stale-value-troubleshoot/tests/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?

--- a/tasks/troubleshooting-multiservice/troubleshoot-asg-ssh-connectivity/tests/test.sh
+++ b/tasks/troubleshooting-multiservice/troubleshoot-asg-ssh-connectivity/tests/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?

--- a/tasks/troubleshooting-multiservice/troubleshoot-glue-job-table-read-failure/tests/test.sh
+++ b/tasks/troubleshooting-multiservice/troubleshoot-glue-job-table-read-failure/tests/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?

--- a/tasks/troubleshooting-multiservice/verify-ec-traffic-routes-through-network-firewall/tests/test.sh
+++ b/tasks/troubleshooting-multiservice/verify-ec-traffic-routes-through-network-firewall/tests/test.sh
@@ -23,7 +23,7 @@ while true; do
     # $? right after `fi` is the if-statement's own exit status (0 when the
     # condition is false and there's no else), not the condition's exit
     # status -- capture it inside `else` instead, before anything else runs.
-    if output="$(uvx --from harbor-rewardkit --with boto3 rewardkit /tests 2>&1 | tee /dev/stderr)"; then
+    if output="$(rewardkit /tests 2>&1 | tee /dev/stderr)"; then
         break
     else
         status=$?


### PR DESCRIPTION
## Problem

Every verifier launches the grader through `uvx`:

```bash
uvx --from harbor-rewardkit --with boto3 rewardkit /tests
```

`uvx` builds an **isolated, ephemeral environment** for each invocation — it never consults system site-packages. So on every trial, the verifier re-resolves, re-downloads, and re-installs all 56 packages of the grader's dependency tree, even though the task images already run:

```dockerfile
RUN uv pip install --system --no-cache harbor-rewardkit boto3 pyyaml
```

That pre-install line (present in 123 of 134 task Dockerfiles) was buying nothing: the installed `rewardkit` sat unused at `/usr/local/bin/rewardkit` while `uvx` rebuilt the same environment beside it, once per trial.

## Fix

Call the pre-installed entry point directly:

```bash
rewardkit /tests
```

Three parts:

1. **Introspection** — the canonical `shared/judge/test.sh` launcher changes (the transient-retry wrapper and the `resolve_placeholders.py` step are untouched), then the sync script propagates it into all 99 introspection tasks.
2. **The 11 `reference-architectures/*` Dockerfiles** gain the same pre-install line as the other 123 images — they lacked it, and would break under the new launcher without it. No version pin is introduced; pinning is a separate open decision.
3. **Mutation** — the 35 mutation `tests/test.sh` files are edited individually, since mutation entry points have no shared canonical. 34 used the standard launcher; one (`expand-elasticsearch-cfn-template`) also passed `--with pyyaml`, which is equally covered by the pre-install.

After this change, `uvx` no longer appears anywhere under `tasks/` or `shared/`.

## Verification

- Verified in a freshly built image before the change was authored: `rewardkit` resolves to `/usr/local/bin/rewardkit`, `import rewardkit, boto3, yaml` all succeed (harbor-rewardkit 0.2.0), so the new launcher is a drop-in.
- A `docker build` of a `reference-architectures` task environment confirms the added pre-install line works: `command -v rewardkit` → `/usr/local/bin/rewardkit`.
- All drift checks green: `shared/judge/scripts/sync.sh --check` / `--check-instructions` / `--check-placeholders` / `--check-output-contract`, and `shared/tasks/scripts/sync.sh --check`.
- `make shell`, `make docker`, `make py` green. File modes preserved on every `test.sh` (all remain executable).

**Not verified: reward equivalence.** Grading the same fixture through the old and new launcher should produce identical rewards — the installed package and the `uvx`-resolved package are the same distribution — but this has not been demonstrated end-to-end (it needs a Bedrock token for the judge). Flagging for the reviewer in case the project has a standard fixture for this.

## Trade-off to be aware of

`uvx` provided incidental *isolation*: the verifier ran in its own environment regardless of what the agent did to the container. With this change, an agent that mutates system site-packages during its attempt (e.g. `pip install --system` of a conflicting dependency) could affect the verifier. No current task instructs an agent to do that, but it is a real property change worth a deliberate decision.

## Two follow-ups this PR deliberately does not do

1. **`rc-0.8.0` carries 144 files with the old launcher, 9 of them new tasks that do not exist on `main`.** Whichever lands second — this PR or that branch — will need the same one-line treatment applied to the survivors. Happy to rebase this onto `rc-0.8.0` instead if that is the preferred target.
2. **Nothing prevents a new task from reintroducing `uvx`.** Mutation entry points have no shared canonical and no drift check. A repo-wide check asserting no `uvx --from harbor-rewardkit` under `tasks/` would make this fix durable; suggested as a follow-up rather than bundled here.
