### PR TITLE
fix(remediation-multiservice): request Lambda concurrency quota before deploy

### DIFF
--- a/scenarios/remediation-multiservice/scenario.toml
+++ b/scenarios/remediation-multiservice/scenario.toml
@@ -32,3 +32,14 @@ timeout_sec = 1800.0
 
 [cleanup]
 timeout_sec = 5400.0
+
+[[quotas]]
+account_tag = "PRIMARY"
+region = "us-east-1"
+service_code = "lambda"
+quota_code = "L-B99A9384"
+desired_value = 1000
+# Concurrent executions. The order-ingest stack sets reservedConcurrentExecutions
+# on two functions (4 + 5) and the drain-sqs-backlog task raises the processor's
+# ceiling to 20. Lambda keeps at least 10 unreserved, so a new account at the
+# initial limit of 10 rejects every reserved value. 1000 is the standard default.


### PR DESCRIPTION
## Problem

`remediation-multiservice` fails in `env_setup` on every fresh account. The scheduled runner has 14 of 14 failures since 2026-09-03 (fresh and steady), all with the same CloudFormation error on the order-ingest stack:

```
AWS::Lambda::Function PaymentSettler CREATE_FAILED
Specified ReservedConcurrentExecutions for function decreases account's
UnreservedConcurrentExecution below its minimum value of [10].
```

Cause: `order-ingest-stack.ts` sets `reservedConcurrentExecutions` on two functions (4 + 5), and the `drain-sqs-backlog-with-governed-ceiling` task raises the processor ceiling to 20. Lambda keeps at least 10 executions unreserved. A new account starts at a concurrency limit of 10 (quota `L-B99A9384`), so any reserved value is rejected. The scenario declares no `[[quotas]]`, so nothing raises the limit first.

## Fix

One `[[quotas]]` entry in `scenarios/remediation-multiservice/scenario.toml`: `lambda` / `L-B99A9384` / `1000` in `us-east-1` for the `PRIMARY` account. 1000 is the standard default for established accounts. `aws-bench env init` submits the request; the scheduled runner passes `--wait-for-quotas --quota-timeout 14400`, so the deploy phase starts only after the increase is applied.

## Verification

- Parsed with the framework's `ScenarioManifest.model_validate_toml`: region and account tag satisfy the cross-field rules, quota resolves to `PRIMARY us-east-1 lambda L-B99A9384 1000.0`.
- Same block shape as the existing entries in `compute-and-data` and `api-and-observability`.
- `main` does not carry this scenario, so no forward-port is needed.

## Related

The scheduled runner drops this scenario from its two rc-0.8.0 profiles until this merges (internal CR, linked in the runner package).
