### PR TITLE
fix(reset): wire CLUSTER_NAME into streaming-and-iot reset hooks

### DIFF
--- a/scenarios/streaming-and-iot/reset/post_invokes/ecs-on-ec2-with-cloudmap/post_invoke.py
+++ b/scenarios/streaming-and-iot/reset/post_invokes/ecs-on-ec2-with-cloudmap/post_invoke.py
@@ -79,6 +79,30 @@ def _deregister_task_definition(ecs, task_def: str | None, errors: list[str]) ->
         errors.append(f"deregister task def: {e}")
 
 
+def _delete_cloudmap_service(sd, service_id: str, errors: list[str]) -> None:
+    """Deregister a Cloud Map service's instances, then delete the service.
+
+    DeleteService fails while any instance is still registered, so instances are
+    deregistered first. Best-effort: errors print to stderr.
+    """
+    try:
+        instances = sd.list_instances(ServiceId=service_id).get("Instances") or []
+        for inst in instances:
+            try:
+                sd.deregister_instance(ServiceId=service_id, InstanceId=inst.get("Id"))
+            except ClientError as e:
+                errors.append(f"deregister instance: {e}")
+    except ClientError as e:
+        errors.append(f"list_instances: {e}")
+
+    # Cloud Map sometimes lags after instance deregistration; brief wait.
+    time.sleep(2)
+    try:
+        sd.delete_service(Id=service_id)
+    except ClientError as e:
+        errors.append(f"delete cloudmap service {service_id}: {e}")
+
+
 def _delete_cloudmap(sd, registry_arns: list[str], errors: list[str]) -> None:
     """Delete each Cloud Map service the agent registered, then the namespace."""
     namespace_id: str | None = None
@@ -92,25 +116,7 @@ def _delete_cloudmap(sd, registry_arns: list[str], errors: list[str]) -> None:
         except ClientError as e:
             errors.append(f"get_service {service_id}: {e}")
 
-        # Deregister all instances first (DeleteService fails if any exist).
-        try:
-            instances = sd.list_instances(ServiceId=service_id).get("Instances") or []
-            for inst in instances:
-                try:
-                    sd.deregister_instance(
-                        ServiceId=service_id, InstanceId=inst.get("Id")
-                    )
-                except ClientError as e:
-                    errors.append(f"deregister instance: {e}")
-        except ClientError as e:
-            errors.append(f"list_instances: {e}")
-
-        # Cloud Map sometimes lags after instance deregistration; brief wait.
-        time.sleep(2)
-        try:
-            sd.delete_service(Id=service_id)
-        except ClientError as e:
-            errors.append(f"delete cloudmap service {service_id}: {e}")
+        _delete_cloudmap_service(sd, service_id, errors)
 
     # Find namespace by name if we don't have the id yet.
     if namespace_id is None and CHOSEN_NAMESPACE_NAME:
@@ -133,6 +139,63 @@ def _delete_cloudmap(sd, registry_arns: list[str], errors: list[str]) -> None:
             errors.append(f"delete namespace {namespace_id}: {e}")
 
 
+def _sweep_orphan_namespaces(sd, errors: list[str]) -> None:
+    """Reap agent-created Cloud Map namespaces left with no ECS service to follow.
+
+    When reset has no serviceRegistries to follow -- in the scenario-reset
+    context there is no ``/logs/agent/agent-output.json`` to name the agent's
+    service, so ``CHOSEN_NAMESPACE_NAME`` is empty too -- a Cloud Map namespace
+    the agent created can linger and re-contaminate the account. The scenario's
+    CloudFormation baseline creates no Cloud Map namespace of any type, so every
+    namespace in the account is agent residue and safe to delete, regardless of
+    type (HTTP, DNS_PRIVATE, or DNS_PUBLIC -- the task permits any).
+
+    A namespace cannot be deleted while it still holds services, and ECS service
+    deletion deregisters the Cloud Map instance but leaves the service, so each
+    namespace's services are torn down first.
+
+    Best-effort: errors print to stderr.
+    """
+    try:
+        namespace_ids = [
+            ns["Id"]
+            for page in sd.get_paginator("list_namespaces").paginate()
+            for ns in (page.get("Namespaces") or [])
+            if ns.get("Id")
+        ]
+    except ClientError as e:
+        errors.append(f"list_namespaces (orphan sweep): {e}")
+        return
+
+    for namespace_id in namespace_ids:
+        try:
+            service_ids = [
+                svc["Id"]
+                for page in sd.get_paginator("list_services").paginate(
+                    Filters=[
+                        {
+                            "Name": "NAMESPACE_ID",
+                            "Values": [namespace_id],
+                            "Condition": "EQ",
+                        }
+                    ]
+                )
+                for svc in (page.get("Services") or [])
+                if svc.get("Id")
+            ]
+        except ClientError as e:
+            errors.append(f"list_services ({namespace_id}): {e}")
+            service_ids = []
+
+        for service_id in service_ids:
+            _delete_cloudmap_service(sd, service_id, errors)
+
+        try:
+            sd.delete_namespace(Id=namespace_id)
+        except ClientError as e:
+            errors.append(f"delete orphan namespace {namespace_id}: {e}")
+
+
 def main() -> int:
     ecs = boto3.client("ecs", region_name=REGION)
     sd = boto3.client("servicediscovery", region_name=REGION)
@@ -141,6 +204,13 @@ def main() -> int:
     registries, task_def = _delete_ecs_service(ecs, errors)
     _deregister_task_definition(ecs, task_def, errors)
     _delete_cloudmap(sd, registries, errors)
+
+    # No serviceRegistries were resolved to follow -- in the scenario-reset
+    # context there is no agent-output.json to name the agent's ECS service, so
+    # the targeted teardown above could not reach a namespace. Sweep any
+    # agent-created Cloud Map namespace left behind.
+    if CLUSTER_NAME and not registries:
+        _sweep_orphan_namespaces(sd, errors)
 
     for err in errors:
         print(err, file=sys.stderr)

--- a/scenarios/streaming-and-iot/reset/reset.sh
+++ b/scenarios/streaming-and-iot/reset/reset.sh
@@ -124,6 +124,14 @@ else
     echo "[reset.sh] Running per-task post_invoke scripts..."
     export AWS_PROFILE="PRIMARY"
 
+    # Bridge the scenario reset export to the name the task hooks read. The
+    # ecs-on-ec2-with-cloudmap post_invoke resolves its agent-created ECS
+    # service (and the Cloud Map service/namespace behind it) via
+    # os.environ["CLUSTER_NAME"]; scenario.toml injects that cluster name as
+    # ECS_CLUSTER_NAME through [reset.env]. Without this the hook reads an empty
+    # CLUSTER_NAME, no-ops, and leaves the namespace to re-contaminate the account.
+    export CLUSTER_NAME="${ECS_CLUSTER_NAME:-}"
+
     for task_dir in "${POST_INVOKES_DIR}"/*; do
         [ -d "${task_dir}" ] || continue
         task_name="$(basename "${task_dir}")"

--- a/tasks/streaming-and-iot/ecs-on-ec2-with-cloudmap/post_invoke/post_invoke.py
+++ b/tasks/streaming-and-iot/ecs-on-ec2-with-cloudmap/post_invoke/post_invoke.py
@@ -79,6 +79,30 @@ def _deregister_task_definition(ecs, task_def: str | None, errors: list[str]) ->
         errors.append(f"deregister task def: {e}")
 
 
+def _delete_cloudmap_service(sd, service_id: str, errors: list[str]) -> None:
+    """Deregister a Cloud Map service's instances, then delete the service.
+
+    DeleteService fails while any instance is still registered, so instances are
+    deregistered first. Best-effort: errors print to stderr.
+    """
+    try:
+        instances = sd.list_instances(ServiceId=service_id).get("Instances") or []
+        for inst in instances:
+            try:
+                sd.deregister_instance(ServiceId=service_id, InstanceId=inst.get("Id"))
+            except ClientError as e:
+                errors.append(f"deregister instance: {e}")
+    except ClientError as e:
+        errors.append(f"list_instances: {e}")
+
+    # Cloud Map sometimes lags after instance deregistration; brief wait.
+    time.sleep(2)
+    try:
+        sd.delete_service(Id=service_id)
+    except ClientError as e:
+        errors.append(f"delete cloudmap service {service_id}: {e}")
+
+
 def _delete_cloudmap(sd, registry_arns: list[str], errors: list[str]) -> None:
     """Delete each Cloud Map service the agent registered, then the namespace."""
     namespace_id: str | None = None
@@ -92,25 +116,7 @@ def _delete_cloudmap(sd, registry_arns: list[str], errors: list[str]) -> None:
         except ClientError as e:
             errors.append(f"get_service {service_id}: {e}")
 
-        # Deregister all instances first (DeleteService fails if any exist).
-        try:
-            instances = sd.list_instances(ServiceId=service_id).get("Instances") or []
-            for inst in instances:
-                try:
-                    sd.deregister_instance(
-                        ServiceId=service_id, InstanceId=inst.get("Id")
-                    )
-                except ClientError as e:
-                    errors.append(f"deregister instance: {e}")
-        except ClientError as e:
-            errors.append(f"list_instances: {e}")
-
-        # Cloud Map sometimes lags after instance deregistration; brief wait.
-        time.sleep(2)
-        try:
-            sd.delete_service(Id=service_id)
-        except ClientError as e:
-            errors.append(f"delete cloudmap service {service_id}: {e}")
+        _delete_cloudmap_service(sd, service_id, errors)
 
     # Find namespace by name if we don't have the id yet.
     if namespace_id is None and CHOSEN_NAMESPACE_NAME:
@@ -133,6 +139,63 @@ def _delete_cloudmap(sd, registry_arns: list[str], errors: list[str]) -> None:
             errors.append(f"delete namespace {namespace_id}: {e}")
 
 
+def _sweep_orphan_namespaces(sd, errors: list[str]) -> None:
+    """Reap agent-created Cloud Map namespaces left with no ECS service to follow.
+
+    When reset has no serviceRegistries to follow -- in the scenario-reset
+    context there is no ``/logs/agent/agent-output.json`` to name the agent's
+    service, so ``CHOSEN_NAMESPACE_NAME`` is empty too -- a Cloud Map namespace
+    the agent created can linger and re-contaminate the account. The scenario's
+    CloudFormation baseline creates no Cloud Map namespace of any type, so every
+    namespace in the account is agent residue and safe to delete, regardless of
+    type (HTTP, DNS_PRIVATE, or DNS_PUBLIC -- the task permits any).
+
+    A namespace cannot be deleted while it still holds services, and ECS service
+    deletion deregisters the Cloud Map instance but leaves the service, so each
+    namespace's services are torn down first.
+
+    Best-effort: errors print to stderr.
+    """
+    try:
+        namespace_ids = [
+            ns["Id"]
+            for page in sd.get_paginator("list_namespaces").paginate()
+            for ns in (page.get("Namespaces") or [])
+            if ns.get("Id")
+        ]
+    except ClientError as e:
+        errors.append(f"list_namespaces (orphan sweep): {e}")
+        return
+
+    for namespace_id in namespace_ids:
+        try:
+            service_ids = [
+                svc["Id"]
+                for page in sd.get_paginator("list_services").paginate(
+                    Filters=[
+                        {
+                            "Name": "NAMESPACE_ID",
+                            "Values": [namespace_id],
+                            "Condition": "EQ",
+                        }
+                    ]
+                )
+                for svc in (page.get("Services") or [])
+                if svc.get("Id")
+            ]
+        except ClientError as e:
+            errors.append(f"list_services ({namespace_id}): {e}")
+            service_ids = []
+
+        for service_id in service_ids:
+            _delete_cloudmap_service(sd, service_id, errors)
+
+        try:
+            sd.delete_namespace(Id=namespace_id)
+        except ClientError as e:
+            errors.append(f"delete orphan namespace {namespace_id}: {e}")
+
+
 def main() -> int:
     ecs = boto3.client("ecs", region_name=REGION)
     sd = boto3.client("servicediscovery", region_name=REGION)
@@ -141,6 +204,13 @@ def main() -> int:
     registries, task_def = _delete_ecs_service(ecs, errors)
     _deregister_task_definition(ecs, task_def, errors)
     _delete_cloudmap(sd, registries, errors)
+
+    # No serviceRegistries were resolved to follow -- in the scenario-reset
+    # context there is no agent-output.json to name the agent's ECS service, so
+    # the targeted teardown above could not reach a namespace. Sweep any
+    # agent-created Cloud Map namespace left behind.
+    if CLUSTER_NAME and not registries:
+        _sweep_orphan_namespaces(sd, errors)
 
     for err in errors:
         print(err, file=sys.stderr)


### PR DESCRIPTION
## What

Fix the `streaming-and-iot` scenario reset so it actually tears down the
Cloud Map resources the `ecs-on-ec2-with-cloudmap` task's agent creates
out-of-CloudFormation (a private DNS namespace + Cloud Map service registered
against the pre-deployed ECS cluster).

Two independent commits:

1. **`fix(reset): wire CLUSTER_NAME into streaming-and-iot reset hooks`** — the unblocker.
2. **`fix(reset): reap orphan Cloud Map namespaces in ecs-on-ec2 hook`** — hardening; reviewers can take or defer it independently.

## Why

The scenario-level reset safety net already exists and is complete —
`scenarios/streaming-and-iot/reset/post_invokes/ecs-on-ec2-with-cloudmap/post_invoke.py`
tears down the ECS service, task-def revisions, Cloud Map service, and
namespace — but it silently no-ops because it never receives its inputs:

- `reset.sh` runs each task's `post_invoke` with only `AWS_PROFILE` exported.
  The hook reads `os.environ["CLUSTER_NAME"]`; unset, `describe_services` is
  never called, no `serviceRegistries` are found, and namespace teardown has
  nothing to follow.
- `/logs/agent/agent-output.json` is a per-trial artifact that does not exist
  in the scenario-reset context, so the hook's `CHOSEN_SERVICE_NAME` /
  `CHOSEN_NAMESPACE_NAME` fallbacks are empty too.

The agent-created private DNS namespace therefore lingers and is flagged by the
next run's new-resource scan (`Found 1 new resource(s)` →
`AccountContaminatedError`), which breaks reuse of streaming accounts under
steady-mode account reuse. A downstream evaluation campaign that reuses accounts
is blocked on this fix and will re-pin its dataset reference to `main` once it
merges.

## How

### Commit 1 — wire `CLUSTER_NAME` (the unblocker)

`scenario.toml` already injects the cluster name into the reset container via
`[reset.env] ECS_CLUSTER_NAME = "{{...-ClusterName}}"`. Reset is an
export-resolved phase, so the framework resolves that placeholder from the
scenario's CloudFormation exports and puts `ECS_CLUSTER_NAME` in the reset
container's environment. `reset.sh` just needs to bridge it to the name the hook
reads:

```bash
export CLUSTER_NAME="${ECS_CLUSTER_NAME:-}"
```

added before the `post_invokes` loop (`:-` because `reset.sh` runs under
`set -u`). No `scenario.toml` change needed. This mirrors the working task-level
`[post_invoke.env] CLUSTER_NAME` wiring. With this, the hook resolves the Cloud
Map service via `describe_services` → `serviceRegistries` → `get_service` →
`delete_namespace`.

### Commit 2 — orphan namespace sweep (hardening, deferrable)

When the ECS service is already gone at reset time, there are no
`serviceRegistries` to follow and (no `agent-output.json`) no namespace name to
resolve, so a lingering namespace is still missed. Added a best-effort fallback:
when `CLUSTER_NAME` is set but no registries were found, list all Cloud Map
namespaces and delete each one, tearing down its Cloud Map services first
(`delete_namespace` fails while a service remains, and ECS service deletion
deregisters the instance but leaves the Cloud Map *service* behind).

Safe because the scenario's CloudFormation baseline creates **no** Cloud Map
namespace of any type (verified: the CDK app has zero `servicediscovery`
constructs; `ecs_ecsasg7m4.ts` provisions only VPC + cluster + ASG + launch
template + IAM, and its own comment notes the agent creates the namespace).
Every namespace in the account is therefore agent residue and safe to delete
regardless of type (HTTP, DNS_PRIVATE, DNS_PUBLIC — the task permits any). The
instance-deregister/delete-service teardown was extracted into a shared helper
reused by both the targeted path and the sweep. Best-effort contract preserved:
errors go to stderr and the hook still exits 0.

## Synchronized copies

`tasks/streaming-and-iot/ecs-on-ec2-with-cloudmap/post_invoke/post_invoke.py` is
canonical; the reset copy under
`scenarios/streaming-and-iot/reset/post_invokes/...` is generated by
`shared/tasks/scripts/sync.sh`. Commit 2 edits the canonical copy and re-syncs
the mirror (byte-identical); `./shared/tasks/scripts/sync.sh --check` is clean.
`reset.sh` is scenario-level and hand-maintained (single copy). The executable
bit on `reset.sh` is preserved.

## Testing

- `make shell` (shellcheck, severity=error): clean.
- `make py` (ruff lint + ruff format --check + ty): green.
- `./shared/tasks/scripts/sync.sh --check`: canonical/generated in sync.

No live AWS teardown was run. This is a behavioral reset-hook change, so it needs
live validation in an approved disposable environment — covered by the consuming
campaign's probe lane. The acceptance signal is that a streaming reset leaves no
Cloud Map namespace behind, so the next run's new-resource scan no longer raises
`AccountContaminatedError`.
